### PR TITLE
Ignore generated doc tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Pretty straightforward — after a `:Helptags` I had a dirty submodule. Ignore the tags, like I notice in your [other](https://github.com/tpope/vim-dispatch/blob/master/.gitignore) [plugins](https://github.com/tpope/vim-rails/blob/master/.gitignore).