### PR TITLE
Execute query asynchronously in neovim

### DIFF
--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -144,13 +144,15 @@ function! s:execute_sql(url, in, out, bang) abort
 endfunction
 
 function! s:on_job_output(job_id, data, event) dict abort
-  let self.output[-1] .= a:data[0]
-  call extend(self.output, a:data[1:])
+  call writefile(a:data, self.outfile, 'ab')
+  if bufexists(self.outfile)
+    pedit +%
+  else
+    call s:handle_results(self.conn, self.infile, self.outfile, self.bang)
+  endif
 endfunction
 
 function! s:on_job_complete(job_id, _data, _event) dict abort
-  call writefile(self.output, self.outfile, 'b')
-  call s:handle_results(self.conn, self.infile, self.outfile, self.bang)
   if bufexists(self.buf)
     if getbufvar(self.buf, 'db_current_job')
       call setbufvar(self.buf, 'db_current_job', v:null)

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -109,15 +109,61 @@ function! s:filter(url) abort
   return db#adapter#dispatch(a:url, op)
 endfunction
 
-function! s:filter_write(url, in, out) abort
+function! s:execute_sql(url, in, out, bang) abort
   let cmd = s:filter(a:url) . ' ' .
         \ db#adapter#call(a:url, 'input_flag', [], '< ') . shellescape(a:in)
-  if exists('*systemlist')
-    let lines = systemlist(cmd)
+  if exists('*jobstart')
+    if exists('b:db_current_job') && b:db_current_job
+      throw 'DB: a query is already in progress'
+    else
+      let b:db_current_job = jobstart(cmd, {
+            \ 'on_stdout': function('s:on_job_output'),
+            \ 'on_stderr': function('s:on_job_output'),
+            \ 'on_exit': function('s:on_job_complete'),
+            \ 'output': [''],
+            \ 'conn': a:url,
+            \ 'infile': a:in,
+            \ 'outfile': a:out,
+            \ 'bang': a:bang
+            \ })
+      let b:db_current_job_start = reltime()
+      let b:db_current_job_elapsed = 0.0
+      let b:db_current_job_timer = timer_start(100, 'db#update_current_job_timer', {'repeat': -1})
+    end
   else
-    let lines = split(system(cmd), "\n", 1)
+    if exists('*systemlist')
+      let lines = systemlist(cmd)
+    else
+      let lines = split(system(cmd), "\n", 1)
+    endif
+    call writefile(lines, a:out, 'b')
+    call s:handle_results(a:url, a:in, a:out, a:bang)
+  end
+endfunction
+
+function! s:on_job_output(job_id, data, event) dict abort
+  let self.output[-1] .= a:data[0]
+  call extend(self.output, a:data[1:])
+endfunction
+
+function! s:on_job_complete(job_id, _data, _event) dict abort
+  if !exists('b:db_current_job') || !b:db_current_job | return | endif
+  call writefile(self.output, self.outfile, 'b')
+  call s:handle_results(self.conn, self.infile, self.outfile, self.bang)
+  unlet b:db_current_job
+  if exists('b:db_current_job_start') | unlet b:db_current_job_start | endif
+endfunction
+
+function! db#update_current_job_timer(_timer)
+  if exists('b:db_current_job_start')
+    let b:db_current_job_elapsed = reltimefloat(reltime(b:db_current_job_start))
+  else
+    if exists('b:db_current_job_timer')
+      call timer_stop(b:db_current_job_timer)
+      unlet b:db_current_job_timer
+    endif
   endif
-  call writefile(lines, a:out, 'b')
+  silent execute 'redrawstatus'
 endfunction
 
 function! db#connect(url) abort
@@ -144,7 +190,7 @@ function! db#connect(url) abort
 endfunction
 
 function! s:reload() abort
-  call s:filter_write(b:db, b:db_input, expand('%:p'))
+  call s:execute_sql(b:db, b:db_input, expand('%:p'), v:false)
   edit!
 endfunction
 
@@ -253,26 +299,7 @@ function! db#execute_command(bang, line1, line2, cmd) abort
       if exists('lines')
         call writefile(lines, infile)
       endif
-      call s:filter_write(conn, infile, outfile)
-      execute 'autocmd BufReadPost' fnameescape(tr(outfile, '\', '/'))
-            \ 'let b:db_input =' string(infile)
-            \ '| let b:db =' string(conn)
-            \ '| let w:db = b:db'
-            \ '| call s:init()'
-      let s:results[conn] = outfile
-      if a:bang
-        silent execute 'botright split' outfile
-      else
-        if db#adapter#call(conn, 'can_echo', [infile, outfile], 0)
-          if v:shell_error
-            echohl ErrorMsg
-          endif
-          echo substitute(join(readfile(outfile), "\n"), "\n*$", '', '')
-          echohl NONE
-          return ''
-        endif
-        silent execute 'botright pedit' outfile
-      endif
+      call s:execute_sql(conn, infile, outfile, a:bang)
     endif
   catch /^DB exec error: /
     redraw
@@ -284,6 +311,28 @@ function! db#execute_command(bang, line1, line2, cmd) abort
     return 'echoerr '.string(v:exception)
   endtry
   return ''
+endfunction
+
+function! s:handle_results(conn, infile, outfile, bang) abort
+  execute 'autocmd BufReadPost' fnameescape(tr(a:outfile, '\', '/'))
+        \ 'let b:db_input =' string(a:infile)
+        \ '| let b:db =' string(a:conn)
+        \ '| let w:db = b:db'
+        \ '| call s:init()'
+  let s:results[a:conn] = a:outfile
+  if a:bang
+    silent execute 'botright split' a:outfile
+  else
+    if db#adapter#call(a:conn, 'can_echo', [a:infile, a:outfile], 0)
+      if v:shell_error
+        echohl ErrorMsg
+      endif
+      echo substitute(join(readfile(a:outfile), "\n"), "\n*$", '', '')
+      echohl NONE
+      return ''
+    endif
+    silent execute 'botright pedit' a:outfile
+  endif
 endfunction
 
 function! s:glob(pattern, prelength) abort


### PR DESCRIPTION
Related to #27. I was also missing this functionality as I was working on some long running queries. Decided to implement it for neovim.

I don't expect this to be merged back as is. It's been a long time since my vim scripting days and I'm sure there is room for improvement in this code. Some things might make sense to make configurable (e.g. the elapsed time counter). And there's the obvious lack of support for vim 8 jobs. I can't invest time in the latter as I'm not using vim 8.

Nevertheless, if you find this useful I'm happy to learn how it could be made better.

### Elapsed time

In addition to executing the query in the background the script also starts a timer to monitor the executing time. It updates a buffer local variable `b:db_current_job_elapsed` with the elapsed time in seconds (type float). This can be used to add information about the current/last query execution time in the statusline. With airline I'm using this:

```vim
" show running time of current query in airline
function! AirlineInit()
  call airline#parts#define('db_current', {
        \ 'raw': '%{exists("b:db_current_job_elapsed") ? printf("\u00a0 DB: %.1fs", b:db_current_job_elapsed) : ""}',
        \ 'accent': 'blue'
        \ })
  let g:airline_section_x = airline#section#create(['tagbar', 'gutentags', 'grepper', 'filetype', 'db_current'])
endfunction
autocmd User AirlineAfterInit call AirlineInit()
```