### PR TITLE
Support osquery

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,7 @@ take on [dbext.vim][], improving on it on the following ways:
   - MongoDB
   - MySQL
   - Oracle
+  - osquery
   - PostgreSQL
   - Presto
   - Redis

--- a/autoload/db/adapter/osquery.vim
+++ b/autoload/db/adapter/osquery.vim
@@ -1,0 +1,33 @@
+if exists('g:autoloaded_db_osquery')
+  finish
+endif
+let g:autoloaded_db_osquery = 1
+
+function! db#adapter#osquery#canonicalize(url) abort
+  return db#url#canonicalize_file(a:url)
+endfunction
+
+function! db#adapter#osquery#dbext(url) abort
+  return {'dbname': s:path(a:url)}
+endfunction
+
+function! db#adapter#osquery#command(url) abort
+  let path = db#url#file_path(a:url)
+  let cmd = 'osqueryi'
+  if strlen(path) > 0
+    let cmd = cmd . ' --db_path ' . shellescape(path)
+  endif
+  return cmd
+endfunction
+
+function! db#adapter#osquery#interactive(url) abort
+  return db#adapter#osquery#command(a:url)
+endfunction
+
+function! db#adapter#osquery#tables(url) abort
+  return split(system(db#adapter#osquery#command(a:url) . ' -noheader -cmd .tables'), "\n")
+endfunction
+
+function! db#adapter#osquery#massage(input) abort
+  return a:input . "\n;"
+endfunction

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -105,6 +105,17 @@ PostgreSQL ~
 <
 For interop, postgres:// URLs are also accepted.
 
+                                                *dadbod-osquery*
+osquery ~
+>
+    osquery:relative/path
+    osquery:/absolute/path
+    osquery:C:/windows/path
+    osquery:///relative/or/absolute/path
+<
+An empty path portion uses an in-memory database, which is how osquery is
+typically invoked.
+
                                                 *dadbod-presto*
 Presto ~
 >


### PR DESCRIPTION
It turns out that the osqueryi CLI is a modified version of sqlite's so very little needed to be changed. The main thing worth noting is that in-memory is the typical invocation.

Closes #34 