### PR TITLE
Add support for command modifiers

### DIFF
--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -172,6 +172,7 @@ function! db#unlet() abort
 endfunction
 
 function! db#execute_command(mods, bang, line1, line2, cmd) abort
+  let mods = a:mods ==# '<mods>' ? '' : a:mods
   if type(a:cmd) == type(0)
     " Error generating arguments
     return ''
@@ -261,7 +262,7 @@ function! db#execute_command(mods, bang, line1, line2, cmd) abort
             \ '| call s:init()'
       let s:results[conn] = outfile
       if a:bang
-        silent execute a:mods 'botright split' outfile
+        silent execute mods 'botright split' outfile
       else
         if db#adapter#call(conn, 'can_echo', [infile, outfile], 0)
           if v:shell_error
@@ -271,7 +272,7 @@ function! db#execute_command(mods, bang, line1, line2, cmd) abort
           echohl NONE
           return ''
         endif
-        silent execute a:mods 'botright pedit' outfile
+        silent execute mods 'botright pedit' outfile
       endif
     endif
   catch /^DB exec error: /

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -171,7 +171,7 @@ function! db#unlet() abort
   unlet! s:db
 endfunction
 
-function! db#execute_command(bang, line1, line2, cmd) abort
+function! db#execute_command(mods, bang, line1, line2, cmd) abort
   if type(a:cmd) == type(0)
     " Error generating arguments
     return ''
@@ -261,7 +261,7 @@ function! db#execute_command(bang, line1, line2, cmd) abort
             \ '| call s:init()'
       let s:results[conn] = outfile
       if a:bang
-        silent execute 'botright split' outfile
+        silent execute a:mods 'botright split' outfile
       else
         if db#adapter#call(conn, 'can_echo', [infile, outfile], 0)
           if v:shell_error
@@ -271,7 +271,7 @@ function! db#execute_command(bang, line1, line2, cmd) abort
           echohl NONE
           return ''
         endif
-        silent execute 'botright pedit' outfile
+        silent execute a:mods 'botright pedit' outfile
       endif
     endif
   catch /^DB exec error: /

--- a/plugin/dadbod.vim
+++ b/plugin/dadbod.vim
@@ -27,7 +27,7 @@ call extend(g:dbext_schemes, {
       \ }, 'keep')
 
 command! -bang -nargs=? -range=-1 -complete=custom,db#command_complete DB
-      \ exe db#execute_command(<mods>, <bang>0, <line1>, <count>, substitute(<q-args>,
+      \ exe db#execute_command('<mods>', <bang>0, <line1>, <count>, substitute(<q-args>,
       \ '^[al]:\w\+\>\ze\s*\%($\|[^[:space:]=]\)', '\=eval(submatch(0))', ''))
 
 function! s:manage_dbext() abort

--- a/plugin/dadbod.vim
+++ b/plugin/dadbod.vim
@@ -27,7 +27,7 @@ call extend(g:dbext_schemes, {
       \ }, 'keep')
 
 command! -bang -nargs=? -range=-1 -complete=custom,db#command_complete DB
-      \ exe db#execute_command(<q-mods>, <bang>0, <line1>, <count>, substitute(<q-args>,
+      \ exe db#execute_command(<mods>, <bang>0, <line1>, <count>, substitute(<q-args>,
       \ '^[al]:\w\+\>\ze\s*\%($\|[^[:space:]=]\)', '\=eval(submatch(0))', ''))
 
 function! s:manage_dbext() abort

--- a/plugin/dadbod.vim
+++ b/plugin/dadbod.vim
@@ -27,7 +27,7 @@ call extend(g:dbext_schemes, {
       \ }, 'keep')
 
 command! -bang -nargs=? -range=-1 -complete=custom,db#command_complete DB
-      \ exe db#execute_command(<bang>0, <line1>, <count>, substitute(<q-args>,
+      \ exe db#execute_command(<q-mods>, <bang>0, <line1>, <count>, substitute(<q-args>,
       \ '^[al]:\w\+\>\ze\s*\%($\|[^[:space:]=]\)', '\=eval(submatch(0))', ''))
 
 function! s:manage_dbext() abort


### PR DESCRIPTION
Addresses #38 

The one downside is that `previewheight` is, by default, `12`. So the `pedit` version of this when split vertically is usually too small to be useful. I'm just wrapping this and temporarily setting `previewheight` larger for my uses. Incidentally, I noticed there is a `split` version of `:DB` when `<bang>` is provided that is undocumented. Maybe that's on purpose because you really shouldn't be editing this file?