### PR TITLE
add completion to sqlserver adapter

### DIFF
--- a/autoload/db/adapter/sqlserver.vim
+++ b/autoload/db/adapter/sqlserver.vim
@@ -46,3 +46,17 @@ function! db#adapter#sqlserver#dbext(url) abort
         \ 'integratedlogin': !has_key(url, 'user'),
         \ }
 endfunction
+
+function! s:complete(url, query) abort
+  let cmd = db#adapter#sqlserver#interactive(a:url)
+  let out = system(cmd . ' -h-1 -W -Q "SET NOCOUNT ON; ' . a:query . '"')
+  return v:shell_error ? [] : map(split(out, "\n"), 'matchstr(v:val, "\\S\\+")')
+endfunction
+
+function! db#adapter#sqlserver#complete_database(url) abort
+  return s:complete(matchstr(a:url, '^[^:]\+://.\{-\}/'), 'SELECT NAME FROM sys.sysdatabases')
+endfunction
+
+function! db#adapter#sqlserver#tables(url) abort
+  return s:complete(a:url, 'SELECT TABLE_NAME FROM information_schema.tables ORDER BY TABLE_NAME')
+endfunction


### PR DESCRIPTION
Hi Tim - thanks for this plugin! I use it all the time at work with a SQL Server database. I added some functions to support command line completion for the sqlserver adapter. I'm not really a SQL Server expert so this is definitely a "works for me" PR, but might not work for all versions of SQL Server or on all OSes etc. 🤷‍♂ 

I shamelessly copied the code from the mongodb adapter and modified it as necessary to work so I might've missed some stuff. More than happy to fix any problems or add any necessary polish.

Thanks!