### PR TITLE
Fix PostgreSQL on Windows to get tables correctly

### DIFF
--- a/autoload/db/adapter/postgresql.vim
+++ b/autoload/db/adapter/postgresql.vim
@@ -15,12 +15,12 @@ endfunction
 
 function! db#adapter#postgresql#interactive(url, ...) abort
   let short = matchstr(a:url, '^[^:]*:\%(///\)\=\zs[^/?#]*$')
-  return 'psql -w ' . (a:0 ? a:1 . ' ' : '') . shellescape(len(short) ? short : a:url)
+  return 'psql -w ' . (a:0 ? a:1 . ' ' : '') . '--dbname ' . shellescape(len(short) ? short : a:url)
 endfunction
 
 function! db#adapter#postgresql#filter(url) abort
   return db#adapter#postgresql#interactive(a:url,
-        \ '-P columns=' . &columns . ' -v ON_ERROR_STOP=1 -f -')
+        \ '-P columns=' . &columns . ' -v ON_ERROR_STOP=1')
 endfunction
 
 function! s:parse_columns(output, ...) abort


### PR DESCRIPTION
Fixed an issue (#61) that did not work properly with PostgreSQL on Windows.

Changed the options of the command used when connecting.

* Use `--dbname`.
* Delete `-f -`.

We can use `--dbname`, as shown in [psql docs](https://www.postgresql.org/docs/12/app-psql.html#:~:text=-d).
This may be handled correctly by adding a `--dbname`, as in [this](https://github.com/sqitchers/sqitch/commit/3e8975f2d86d35ff2f44cbb14fe6daf2e8d4587a).

Also, I had to remove the `-f -` to get it to work in Windows.


I'm not familiar with PostgreSQL, nor am I familiar with Windows, but I'm happy to help.

Thank you!