### PR TITLE
Add MongoDB authSource param support

### DIFF
--- a/autoload/db/adapter/mongodb.vim
+++ b/autoload/db/adapter/mongodb.vim
@@ -17,7 +17,9 @@ endfunction
 
 function! db#adapter#mongodb#interactive(url) abort
   let url = db#url#parse(a:url)
-  return 'mongo' . (get(url.params, 'ssl') =~# '^[1t]' ? ' --ssl' : '') .
+  let params = db#url#parse(a:url).params
+  return 'mongo ' . (get(params, 'ssl') =~# '^[1t]' ? ' --ssl' : '') .
+        \ (has_key(params, 'authSource') ? ' --authenticationDatabase ' . params['authSource'] : '') .
         \ db#url#as_args(url, '--host ', '--port ', '', '-u ', '-p ', '')
 endfunction
 


### PR DESCRIPTION
Support for specifying the authentication database name within the MongoDB URL.

`:echo db#adapter#dispatch("mongodb://user@127.0.0.1:27017/db?authSource=admin&ssl=true", "interactive")`

`mongo  --ssl --authenticationDatabase admin --host '127.0.0.1' --port '27017' -u 'user' 'db'`

`defaultauthdb` = URL path / the database name
`authSource` = URL param to override `defaultauthdb`
`authenticationDatabase` = `mongo` cmd option.

**Authentication datatabase**
> When adding a user, you create the user in a specific database. This database is the authentication database for the user.

Source: https://docs.mongodb.com/manual/core/security-users/#user-authentication-database

**authSource**
> Specify the database name associated with the user’s credentials. If authSource is unspecified, authSource defaults to the defaultauthdb specified in the connection string. If defaultauthdb is unspecified, then authSource defaults to admin.
> 
> For authentication mechanisms that delegate credential storage to other services, the authSource value should be $external as with the PLAIN (LDAP) and GSSAPI (Kerberos) authentication mechanisms.
> 
> MongoDB will ignore authSource values if the connection string specifies no username.

Source: https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource

**authenticationDatabase**
> --authenticationDatabase <dbname>
> Specifies the authentication database where the specified --username has been created. See Authentication Database.
> 
> If you do not specify a value for --authenticationDatabase, mongo uses the database specified in the connection string.

Source: https://docs.mongodb.com/manual/reference/program/mongo/#cmdoption-mongo-authenticationdatabase