### PR TITLE
Allow '@' on password field for mysql connections.

### DIFF
--- a/autoload/db/url.vim
+++ b/autoload/db/url.vim
@@ -27,7 +27,7 @@ function! db#url#parse(url) abort
   endfor
   let url = substitute(a:url, '?.*', '', '')
   let scheme = '^\([[:alnum:].+-]\+\)'
-  let match = matchlist(url, scheme . '://\%(\([^@/:]*\):\=\([^@/]*\)@\)\=\(\[[[:xdigit:]:]\+\]\|[^:/;,]*\)\%(:\(\d\+\)\)\=\($\|/.*\)')
+  let match = matchlist(url, scheme . '://\%(\([^@/:]*\):\=\([^/]*\)@\)\=\(\[[[:xdigit:]:]\+\]\|[^:/;,]*\)\%(:\(\d\+\)\)\=\($\|/.*\)')
   if !empty(match)
     return filter({
           \ 'scheme': match[1],


### PR DESCRIPTION
Hi, Mr. Pope.

I did a little change in the regular expression that handles the connection string of MySQL databases. The '@' sign is allowed in the user password and happens that I have this on a production database. I did some tests with others databases/passwords and seams that the change didn't affect the behavior negatively.

Regards.