### PR TITLE
Add mysql protocol option

### DIFF
--- a/autoload/db/adapter/mysql.vim
+++ b/autoload/db/adapter/mysql.vim
@@ -20,7 +20,7 @@ function! s:command_for_url(url) abort
   let params = db#url#parse(a:url).params
   return 'mysql' .
         \ (has_key(params, 'login-path') ? ' --login-path=' . shellescape(params['login-path'])  : '') .
-        \ (has_key(params, 'protocol') ? ' --protocol=' . params['protocol']  : '') .
+        \ (has_key(params, 'protocol') ? ' --protocol=' . shellescape(params['protocol'])  : '') .
         \ db#url#as_args(a:url, '-h ', '-P ', '-S ', '-u ', '-p', '')
 endfunction
 

--- a/autoload/db/adapter/mysql.vim
+++ b/autoload/db/adapter/mysql.vim
@@ -13,14 +13,14 @@ function! db#adapter#mysql#canonicalize(url) abort
         \ 'password': 'password',
         \ 'path': 'host',
         \ 'host': 'host',
-        \ 'port': 'port',
-        \ 'protocol': ''})
+        \ 'port': 'port'})
 endfunction
 
 function! s:command_for_url(url) abort
   let params = db#url#parse(a:url).params
   return 'mysql' .
         \ (has_key(params, 'login-path') ? ' --login-path=' . shellescape(params['login-path'])  : '') .
+        \ (has_key(params, 'protocol') ? ' --protocol=' . params['protocol']  : '') .
         \ db#url#as_args(a:url, '-h ', '-P ', '-S ', '-u ', '-p', '')
 endfunction
 


### PR DESCRIPTION
Added support for the --protocol= flag to the mysql adapter.  I also noticed that there was a placeholder for 'protocol' in the call to absorb_params.  I removed that since setting the value of the 'protocol' key in the params dictionary to an empty string will cause it to be removed in absorb_params and consequently not propagated through as part of the params dictionary in the ultimate db#url#parse call in s:command_for_url.  I tested this in my local branch, and it allows me to communicate with a ClickHouse server that adheres to the mysql tcp protocol using a :DB command like this:
`:DB mysql://default@localhost:9004/some_data?protocol=TCP`