### PR TITLE
Add configurable usage HTTP interface for ClickHouse

### DIFF
--- a/autoload/db/adapter/clickhouse.vim
+++ b/autoload/db/adapter/clickhouse.vim
@@ -3,6 +3,11 @@ if exists('g:autoloaded_db_clickhouse')
 endif
 let g:autoloaded_db_clickhouse = 1
 
+if ! exists('g:db_clickhouse_client')
+  let g:db_clickhouse_client = 'undefined'
+endif
+
+
 function! db#adapter#clickhouse#canonicalize(url) abort
   let url = substitute(a:url, '^[^:]*:/\=/\@!', 'clickhouse:///', '')
   return db#url#absorb_params(url, {
@@ -25,7 +30,8 @@ function! s:process_url(url) abort
   return url
 endfunction
 
-function! db#adapter#clickhouse#interactive(url, ...) abort
+" Uses native binary for interactive session and filter
+function! s:clickhouse_native_client(url) abort
   let url = s:process_url(a:url)
   let cmd = 'clickhouse-client'
   if has_key(url.params, 'secure')
@@ -39,8 +45,75 @@ function! db#adapter#clickhouse#interactive(url, ...) abort
         \ db#url#as_args(a:url, '--host ', '--port ', '', '--user ', '--port ', '--database ')
 endfunction
 
-function! db#adapter#clickhouse#complete_opaque(_) abort
-  return db#adapter#clickhouse#complete_database('clickhouse:///')
+" Use HTTP ClickHouse interface for filtering.
+" Interactive is not implemented
+function! s:clickhouse_curl_client(url) abort
+  let cmd = 'curl -s --data-binary @-'
+  let url = s:process_url(a:url)
+
+  if has_key(url.params, 'secure')
+    let scheme = 'https'
+    unlet url.params.secure
+  else
+    let scheme = 'http'
+  endif
+
+  if get(url, 'host', 0) isnot 0
+    let host = get(url, 'host')
+  else
+    let host = 'localhost'
+  endif
+
+  if get(url, 'port', 0) isnot 0
+    let port = get(url, 'port')
+  else
+    let port = scheme ==# 'http' ? 8123 : 8443
+  endif
+
+  if get(url, 'user', 0) isnot 0
+    let url.params.user = url.user
+  endif
+  if get(url, 'password', 0) isnot 0
+    let url.params.password = url.password
+  endif
+
+  if get(url, 'path', '') !~# '^/\=$'
+    let url.params.database = substitute(url.path, '^/', '', '')
+  elseif has_key(url, 'opaque')
+    let url.params.database = db#url#decode(substitute(url.opaque, '?.*', '', ''))
+  endif
+
+  " Special processing `format` parameter
+  if get(url.params, 'format', 0) isnot 0
+    let cmd .= ' -H ' . shellescape("X-ClickHouse-Format: " . url.params.format)
+    unlet url.params.format
+  endif
+
+  let uri = scheme . '://' . host . ':' . port . '/?query'
+  for [k, v] in items(url.params)
+    let uri .= '&' . k . '=' . db#url#encode(v)
+  endfor
+
+  let cmd .= ' ' . shellescape(uri)
+  return cmd
+endfunction
+
+function! db#adapter#clickhouse#interactive(url) abort
+  if g:db_clickhouse_client ==# 'curl'
+    throw 'echoerr "DB: interactive mode is disabled"'
+  elseif executable('clickhouse-client') || g:db_clickhouse_client ==# 'native'
+    return s:clickhouse_native_client(a:url)
+  endif
+  throw 'echoerr "DB: interactive mode requires clickhouse-client"'
+endfunction
+
+function! db#adapter#clickhouse#filter(url) abort
+  if g:db_clickhouse_client ==# 'curl'
+    return s:clickhouse_curl_client(a:url)
+  elseif executable('clickhouse-client') || g:db_clickhouse_client ==# 'native'
+    return s:clickhouse_native_client(a:url)
+  endif
+  return s:clickhouse_curl_client(a:url)
 endfunction
 
 function! db#adapter#clickhouse#auth_input() abort

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -88,7 +88,21 @@ It has two special parameters:
 * secure: if set to "1", "true" or "True", TLS is used
 * format: any valid ClickHouse format
 
-Example: clickhouse:///database?format=PrettyNoEscape&secure=1
+Example:
+>
+    clickhouse:///database?format=PrettyNoEscape&secure=1
+<
+
+NOTE: if `clickhouse-client` binary exists, then it will be used together with
+TCP protocol, otherwise the plugin uses `curl` and HTTP protocol. There is a way to
+force one or another by setting `g:db_clickhouse_client` variable.
+
+                                                *g:db_clickhouse_client*
+>
+    let g:db_clickhouse_client = 'native'
+    " or
+    let g:db_clickhouse_client = 'curl'
+<
 
                                                 *dadbod-impala*
 Impala ~


### PR DESCRIPTION
The native-only interface is implement in #83 

This PR adds a fallback to the HTTP interface when `clickhouse-client` is not found in $PATH, or `g:db_clickhouse_client` is set to `curl`