### PR TITLE
Improve ClickHouse: add stand-alone parameters support

### DIFF
--- a/autoload/db/adapter/clickhouse.vim
+++ b/autoload/db/adapter/clickhouse.vim
@@ -13,27 +13,18 @@ function! db#adapter#clickhouse#canonicalize(url) abort
         \ 'database': 'database'})
 endfunction
 
-function! s:process_url(url) abort
-  " Function moves special parameters to url
-  "  secure: http/https, 1 ot 'true' for
-  let url = db#url#parse(a:url)
-  if get(url.params, 'secure') =~# '^[1Tt]'
-    let url.params.secure = ''
-  elseif has_key(url.params, 'secure')
-    unlet url.params.secure
-  endif
-  return url
-endfunction
-
 function! db#adapter#clickhouse#interactive(url, ...) abort
-  let url = s:process_url(a:url)
+  let url = db#url#parse(a:url)
   let cmd = ['clickhouse-client']
-  if has_key(url.params, 'secure')
-    call add(cmd, '--secure')
-    unlet url.params.secure
-  endif
   for [k, v] in items(url.params)
-    call extend(cmd, ['--' . k, v])
+    " All settings without value are passed as single argument, for example:
+    " ?secure => --secure
+    " ?multiquery => --multiquery
+    if v != 1
+      call extend(cmd, ['--' . k, v])
+    else
+      call extend(cmd, ['--' . k])
+    endif
   endfor
   return cmd +
         \ db#url#as_argv(a:url, '--host ', '--port ', '', '--user ', '--port ', '--database ')

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -86,11 +86,15 @@ For supported adapters, dbext modelines and profiles can be used directly.
                                                 *dadbod-clickhouse*
 ClickHouse ~
 >
-    clickhouse://[<host>[:port]]/[<database>]
-    clickhouse:[database]
+    clickhouse://[<host>[:port]]/[<database>][?[setting=arg][&setting-without-argument]]
+    clickhouse:[database][?[setting=arg][&setting-without-argument]]
 <
-Use the `secure` query parameter to enable TLS, and the `format` query
-parameter to set the ClickHouse format (e.g., PrettyNoEscape).
+`clickhouse-client` supports two types of command line parameters:
+
+* without additional arguments, e.g. `--secure` and `--multiquery`;
+* with parameters, e.g. `--max_final_threads arg`.
+
+To pass parameter without argument use `clickhouse:?secure` notation.
 
                                                 *dadbod-impala*
 Impala ~


### PR DESCRIPTION
After recent refactoring, it's possible to simplify `cmd` generation with proper processing of stand-alone arguments like `--secure`, `--multiline`, `--multiquery` and so on.

This PR implements the processing for URL parameters w/o values.