### PR TITLE
bugfix: remove space which causes fail to connect redis

### DIFF
--- a/autoload/db/adapter/redis.vim
+++ b/autoload/db/adapter/redis.vim
@@ -12,7 +12,7 @@ function! db#adapter#redis#canonicalize(url) abort
 endfunction
 
 function! db#adapter#redis#interactive(url) abort
-  return ['redis-cli'] + db#url#as_argv(a:url, '-h ', '-p ', '', '', ' -a ', '-n ')
+  return ['redis-cli'] + db#url#as_argv(a:url, '-h ', '-p ', '', '', '-a ', '-n ')
 endfunction
 
 function! db#adapter#redis#can_echo(in, out) abort


### PR DESCRIPTION
The space will cause `args` list have a `''` item which causes failing to connect redis