### PR TITLE
Allow mysql adapter to accept any command line options

### DIFF
--- a/autoload/db/adapter/mysql.vim
+++ b/autoload/db/adapter/mysql.vim
@@ -18,13 +18,13 @@ endfunction
 
 function! s:command_for_url(url) abort
   let params = db#url#parse(a:url).params
-  return ['mysql'] +
-        \ (has_key(params, 'login-path') ? ['--login-path=' . params['login-path']]  : []) +
-        \ (has_key(params, 'protocol') ? ['--protocol=' . params['protocol']] : []) +
-        \ (has_key(params, 'ssl-ca') ? ['--ssl-ca=' . params['ssl-ca']]  : []) +
-        \ (has_key(params, 'ssl-cert') ? ['--ssl-cert=' . params['ssl-cert']]  : []) +
-        \ (has_key(params, 'ssl-key') ? ['--ssl-key=' . params['ssl-key']]  : []) +
-        \ db#url#as_argv(a:url, '-h ', '-P ', '-S ', '-u ', '-p', '')
+  let command = ['mysql']
+
+  for i in keys(params)
+    let command += ['--'.i.'='.params[i]]
+  endfor
+
+  return command + db#url#as_argv(a:url, '-h ', '-P ', '-S ', '-u ', '-p', '')
 endfunction
 
 function! db#adapter#mysql#interactive(url) abort

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -126,8 +126,8 @@ MySQL ~
     mysql://[<user>[:<password>]@][<%2Fsocket%2Fpath>]/[<database>]
     mysql:[<database>]
 <
-Supported query parameters are `login-path`, `protocol`, `ssl-ca`, `ssl-cert`, and
-`ssl-key`, which pass the corresponding command line optins.
+Query parameters such as `login-path`, `protocol`, `ssl-ca`, `ssl-cert`, and
+`ssl-key` are passed as the corresponding command line options.
 
                                                 *dadbod-oracle*
 Oracle ~


### PR DESCRIPTION
I was going to add `--ssl-mode=` option and test out some connection issues I had, but then I thought there are no reasons to babysit the user for the command line options they want to use?