### PR TITLE
Provide arguments to bufnr in 'db#cancel' for older vim versions

### DIFF
--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -132,7 +132,7 @@ function! s:canonicalize(url) abort
 endfunction
 
 function! db#cancel(...) abort
-  let buf = get(a:, 1, bufnr())
+  let buf = get(a:, 1, bufnr(''))
   return s:job_cancel(getbufvar(buf, 'db_job_id', ''))
 endfunction
 


### PR DESCRIPTION
I ran into an issue related to [Issue 93](https://github.com/tpope/vim-dadbod/issues/93) that was fixed in 1.4 . I'm running neovim 0.3.4 and would get errors caused by missing parameters to `bufnr()` in `db#cancel`. Providing an empty string as parameter to `bufnr()` there as well fixes the issue for me.