### PR TITLE
Pass stdin file through job options to Vim job_start

### DIFF
--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -192,6 +192,9 @@ function! s:systemlist_with_err(cmd) abort
   let job_result = { 'content': [], 'status': 0 }
   let job = s:job_run(cmd, function('s:systemlist_job_cb', [job_result]), stdin_file)
   call s:job_wait(job)
+  if has('win32')
+    call map(job_result.content, { _, v -> substitute(v, "\r$", "", "") })
+  endif
   return [job_result.content, job_result.status]
 endfunction
 

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -614,12 +614,10 @@ endfunction
 
 function! s:nvim_job_callback(jobid, data, event) dict abort
   if a:event ==? 'exit'
-    if len(self.output) && empty(self.output[-1])
-      call remove(self.output, -1)
-    endif
     return self.on_finish(self.output, a:data)
   endif
-  call extend(self.output, a:data)
+  let self.output[-1] .= a:data[0]
+  call extend(self.output, a:data[1:])
 endfunction
 
 function! s:job_run(cmd, on_finish, stdin_file, ...) abort
@@ -629,10 +627,8 @@ function! s:job_run(cmd, on_finish, stdin_file, ...) abort
           \ 'on_stdout': function('s:nvim_job_callback'),
           \ 'on_stderr': function('s:nvim_job_callback'),
           \ 'on_exit': function('s:nvim_job_callback'),
-          \ 'output': [],
+          \ 'output': [''],
           \ 'on_finish': a:on_finish,
-          \ 'stdout_buffered': 1,
-          \ 'stderr_buffered': 1,
           \ })
 
     if !empty(a:stdin_file) && filereadable(a:stdin_file)

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -184,6 +184,9 @@ function! db#systemlist(cmd, ...) abort
   if !empty(job_result.status)
     return []
   endif
+  if len(job_result.content) && empty(job_result.content[-1])
+    call remove(job_result.content, -1)
+  endif
   return job_result.content
 endfunction
 
@@ -192,6 +195,9 @@ function! s:systemlist_with_err(cmd) abort
   let job_result = { 'content': [], 'status': 0 }
   let job = s:job_run(cmd, function('s:systemlist_job_cb', [job_result]), stdin_file)
   call s:job_wait(job)
+  if len(job_result.content) && empty(job_result.content[-1])
+    call remove(job_result.content, -1)
+  endif
   return [job_result.content, job_result.status]
 endfunction
 

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -681,28 +681,18 @@ function! s:job_run(cmd, on_finish, stdin_file, ...) abort
   throw 'DB: jobs not supported by this vim version.'
 endfunction
 
-function! s:job_wait(job, ...) abort
-  let timeout = get(a:, 1, -1)
-
+function! s:job_wait(job) abort
   if has('nvim')
-    return jobwait([a:job], timeout)[0] == -1 ? v:false : v:true
+    return jobwait([a:job])[0] == -1 ? v:false : v:true
   endif
 
-  let finished = v:true
   if exists('*job_status')
-    let ms = 0
-    let max = timeout
     while job_status(a:job) ==# 'run'
-      if ms == max
-        let finished = v:false
-        break
-      endif
-      let ms += 1
       sleep 1m
     endwhile
   endif
 
-  return finished
+  return v:true
 endfunction
 
 function! s:job_cancel(job) abort

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -598,12 +598,13 @@ function! db#clobber_dbext(...) abort
 endfunction
 
 function! s:vim_job.callback(job, data) dict abort
-  if type(a:data) ==? type(0)
-    let self.exit = 1
-    let self.exit_status = a:data
-    return self.call_on_finish_if_closed()
-  endif
   let self.output .= a:data
+endfunction
+
+function! s:vim_job.exit_cb(job, data) dict abort
+  let self.exit = 1
+  let self.exit_status = a:data
+  return self.call_on_finish_if_closed()
 endfunction
 
 function! s:vim_job.close_cb(channel) dict abort
@@ -654,7 +655,7 @@ function! s:job_run(cmd, on_finish, stdin_file, ...) abort
     let fn.on_finish = a:on_finish
     let opts = {
           \ 'callback': fn.callback,
-          \ 'exit_cb': fn.callback,
+          \ 'exit_cb': fn.exit_cb,
           \ 'close_cb': fn.close_cb,
           \ 'mode': 'raw'
           \ }

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -174,6 +174,9 @@ endfunction
 
 function! s:systemlist_job_cb(data, output, status) abort
   call extend(a:data.content, a:output)
+  if has('win32')
+    call map(a:data.content, { _, v -> substitute(v, "\r$", "", "") })
+  endif
   let a:data.status = a:status
 endfunction
 
@@ -192,9 +195,6 @@ function! s:systemlist_with_err(cmd) abort
   let job_result = { 'content': [], 'status': 0 }
   let job = s:job_run(cmd, function('s:systemlist_job_cb', [job_result]), stdin_file)
   call s:job_wait(job)
-  if has('win32')
-    call map(job_result.content, { _, v -> substitute(v, "\r$", "", "") })
-  endif
   return [job_result.content, job_result.status]
 endfunction
 

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -608,11 +608,7 @@ endfunction
 
 function! s:vim_job.call_on_finish_if_closed() abort
   if self.close && self.exit
-    let output = split(self.output, "\n", 1)
-    if len(output) && empty(output[-1])
-      call remove(output, -1)
-    endif
-    return self.on_finish(output, self.exit_status)
+    return self.on_finish(split(self.output, "\n", 1), self.exit_status)
   endif
 endfunction
 


### PR DESCRIPTION
As per [discussion](https://github.com/tpope/vim-dadbod/pull/64#discussion_r979358720), this PR:

* Reverts the previous revert
* Adds the Windows carriage return fix (I didn't confirm if it really works)
* Handles the raw stdin and file stdin separately, and passes the file through job options