### PR TITLE
enh(adapater): add bigquery support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,7 @@ take on [dbext.vim][], improving on it on the following ways:
 * All interaction is through invoking `:DB`, not 53 different commands and 35
   different maps (omitting many of the more esoteric features, of course)
 * Supports a modern array of backends, including NoSQL databases:
+  - Big Query
   - ClickHouse
   - Impala
   - jq

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -42,22 +42,17 @@ let g:bq_global_ops = [
   \ 'nouse_regional_endpoints',
   \ ]
 
-
 function! s:command_for_url(params, action) abort
   let cmd = ['bq']
   let subcmd = [a:action]
-
   for [k, v] in items(a:params)
     let op = '--'.k.'='.v
     if index(g:bq_global_ops, k) >= 0
-      " parse global options
       call add(cmd, op)
     else
-      " parse subcmd options
       call add(subcmd, op)
     endif
   endfor
-
   return cmd + subcmd
 endfunction
 
@@ -72,12 +67,10 @@ function! db#adapter#bigquery#interactive(url, action) abort
 endfunction
 
 function! db#adapter#bigquery#input(url, in) abort
-
   let out = []
   if len(matchstr(a:in, '.sql'))
     let out += db#adapter#bigquery#interactive(a:url, 'query')
-    let out += ['--flagfile=' . a:in]
+    let out += [join(readfile(a:in), ' ')]
   endif
-
   return out
 endfunction

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -70,7 +70,7 @@ function! db#adapter#bigquery#input(url, in) abort
   let out = []
   if len(matchstr(a:in, '.sql'))
     let out += db#adapter#bigquery#interactive(a:url, 'query')
-    let out += [join(readfile(a:in), ' ')]
+    let out += ['--flagfile='.a:in]
   endif
   return out
 endfunction

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -81,21 +81,3 @@ function! db#adapter#bigquery#input(url, in) abort
 
   return out
 endfunction
-
-function! db#adapter#bigquery#complete_database(url) abort
-  let cmd = s:command_for_url(s:params(a:url))
-  let cmd .= ' ls '
-  echom "system" cmd
-  let out = system(cmd)
-  echom "out" out
-  let dbs = []
-
-  for i in split(out, "\n")
-    if len(i) > 2
-      call add(dbs, trim(i))
-    endif
-
-  endfor
-
-  return dbs
-endfunction

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -1,0 +1,81 @@
+if !executable('bq')
+  echom 'bq command is not available.'
+  let g:autoloaded_db_bigquery = 0
+endif
+
+if exists('g:autoloaded_db_bigquery')
+  finish
+endif
+
+let g:autoloaded_db_bigquery = 1
+
+function! s:command_for_url(params, action) abort
+  let cmd = ['bq']
+  let subcmd = [a:action]
+
+  for [k, v] in items(a:params)
+    let op = ' --'.k.'='.v
+
+    if len(matchstr(k, 'legacy'))
+        " FIXME: parse subcmd options
+        call add(subcmd, op)
+    else
+        " parse global options
+        call add(cmd, op)
+    endif
+
+  endfor
+
+  return join(cmd + subcmd)
+
+endfunction
+
+function! s:params(url) abort
+  let parsed_params = db#url#parse(a:url)
+  let conn_params = parsed_params.params
+  return conn_params
+endfunction
+
+function! db#adapter#bigquery#interactive(url, action) abort
+  echom "Starting bigquery"
+  return split(s:command_for_url(s:params(a:url), a:action))
+endfunction
+
+function! db#adapter#bigquery#input(url, in) abort
+
+  " QST: what is the purpose of input?
+  let qry = join(readfile(a:in, 2))
+  if len(qry)
+    " QST: why I have to add this condition?
+    return db#adapter#bigquery#interactive(a:url, "query") + [qry]
+  endif
+
+  return []
+
+endfunction
+
+function! db#adapter#bigquery#complete_opaque(url) abort
+  " QST: don't know why this is required
+  return db#adapter#bigquery#complete_database(a:url)
+endfunction
+
+function! db#adapter#bigquery#complete_database(url) abort
+  let cmd = s:command_for_url(s:params(a:url))
+  let cmd .= ' ls '
+  echom "system" cmd
+  let out = system(cmd)
+  echom "out" out
+  let dbs = []
+
+  " FIXME: this is not working properly
+  for i in split(out, "\n")
+    " let dbname = split(i, "|")
+    if len(i) > 2
+      call add(dbs, trim(i))
+    endif
+
+  endfor
+
+  return dbs
+
+endfunction

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -68,7 +68,6 @@ function! s:params(url) abort
 endfunction
 
 function! db#adapter#bigquery#interactive(url, action) abort
-  echom "Starting bigquery"
   return s:command_for_url(s:params(a:url), a:action)
 endfunction
 

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -1,113 +1,102 @@
-if exists('g:autoloaded_db_bigquery')
-    finish
-endif
-
-let g:autoloaded_db_bigquery = 1
 let g:bq_global_ops = [
-    \ 'api',
-    \ 'api_version',
-    \ 'apilog',
-    \ 'bigqueryrc',
-    \ 'ca_certificates_file',
-    \ 'dataset_id',
-    \ 'debug_mode',
-    \ 'nodebug_mode',
-    \ 'disable_ssl_validation',
-    \ 'nodisable_ssl_validation',
-    \ 'discovery_file',
-    \ 'enable_gdrive',
-    \ 'noenable_gdrive',
-    \ 'fingerprint_job_id',
-    \ 'nofingerprint_job_id',
-    \ 'format',
-    \ 'headless',
-    \ 'noheadless',
-    \ 'httplib2_debuglevel',
-    \ 'job_id',
-    \ 'job_property',
-    \ 'jobs_query_use_request_id',
-    \ 'nojobs_query_use_request_id',
-    \ 'jobs_query_use_results_from_response',
-    \ 'nojobs_query_use_results_from_response',
-    \ 'location',
-    \ 'max_rows_per_request',
-    \ 'mtls',
-    \ 'nomtls',
-    \ 'project_id',
-    \ 'proxy_address',
-    \ 'proxy_password',
-    \ 'proxy_port',
-    \ 'proxy_username',
-    \ 'quiet',
-    \ 'noquiet',
-    \ 'synchronous_mode',
-    \ 'nosynchronous_mode',
-    \ 'trace',
-    \ 'use_regional_endpoints',
-    \ 'nouse_regional_endpoints',
-    \ ]
+  \ 'api',
+  \ 'api_version',
+  \ 'apilog',
+  \ 'bigqueryrc',
+  \ 'ca_certificates_file',
+  \ 'dataset_id',
+  \ 'debug_mode',
+  \ 'nodebug_mode',
+  \ 'disable_ssl_validation',
+  \ 'nodisable_ssl_validation',
+  \ 'discovery_file',
+  \ 'enable_gdrive',
+  \ 'noenable_gdrive',
+  \ 'fingerprint_job_id',
+  \ 'nofingerprint_job_id',
+  \ 'format',
+  \ 'headless',
+  \ 'noheadless',
+  \ 'httplib2_debuglevel',
+  \ 'job_id',
+  \ 'job_property',
+  \ 'jobs_query_use_request_id',
+  \ 'nojobs_query_use_request_id',
+  \ 'jobs_query_use_results_from_response',
+  \ 'nojobs_query_use_results_from_response',
+  \ 'location',
+  \ 'max_rows_per_request',
+  \ 'mtls',
+  \ 'nomtls',
+  \ 'project_id',
+  \ 'proxy_address',
+  \ 'proxy_password',
+  \ 'proxy_port',
+  \ 'proxy_username',
+  \ 'quiet',
+  \ 'noquiet',
+  \ 'synchronous_mode',
+  \ 'nosynchronous_mode',
+  \ 'trace',
+  \ 'use_regional_endpoints',
+  \ 'nouse_regional_endpoints',
+  \ ]
 
 
 function! s:command_for_url(params, action) abort
-    let cmd = ['bq']
-    let subcmd = [a:action]
+  let cmd = ['bq']
+  let subcmd = [a:action]
 
-    for [k, v] in items(a:params)
-        let op = '--'.k.'='.v
-        if index(g:bq_global_ops, k) >= 0
-            " parse global options
-            call add(cmd, op)
-        else
-            " parse subcmd options
-            call add(subcmd, op)
-        endif
-    endfor
+  for [k, v] in items(a:params)
+    let op = '--'.k.'='.v
+    if index(g:bq_global_ops, k) >= 0
+      " parse global options
+      call add(cmd, op)
+    else
+      " parse subcmd options
+      call add(subcmd, op)
+    endif
+  endfor
 
-    return cmd + subcmd
+  return cmd + subcmd
 endfunction
 
 function! s:params(url) abort
-    let parsed_params = db#url#parse(a:url)
-    let conn_params = parsed_params.params
-    return conn_params
+  let parsed_params = db#url#parse(a:url)
+  let conn_params = parsed_params.params
+  return conn_params
 endfunction
 
 function! db#adapter#bigquery#interactive(url, action) abort
-    echom "Starting bigquery"
-    return s:command_for_url(s:params(a:url), a:action)
+  echom "Starting bigquery"
+  return s:command_for_url(s:params(a:url), a:action)
 endfunction
 
 function! db#adapter#bigquery#input(url, in) abort
 
-    let out = []
-    if len(matchstr(a:in, '.sql'))
-        let out += db#adapter#bigquery#interactive(a:url, 'query')
-        let out += ['--flagfile=' . a:in]
-    endif
+  let out = []
+  if len(matchstr(a:in, '.sql'))
+    let out += db#adapter#bigquery#interactive(a:url, 'query')
+    let out += ['--flagfile=' . a:in]
+  endif
 
-    return out
+  return out
 endfunction
 
-" function! db#adapter#bigquery#complete_opaque(url) abort
-"     return db#adapter#bigquery#complete_database(a:url)
-" endfunction
-
 function! db#adapter#bigquery#complete_database(url) abort
-    let cmd = s:command_for_url(s:params(a:url))
-    let cmd .= ' ls '
-    echom "system" cmd
-    let out = system(cmd)
-    echom "out" out
-    let dbs = []
+  let cmd = s:command_for_url(s:params(a:url))
+  let cmd .= ' ls '
+  echom "system" cmd
+  let out = system(cmd)
+  echom "out" out
+  let dbs = []
 
-    " FIXME: this is not working properly
-    for i in split(out, "\n")
-        " let dbname = split(i, "|")
-        if len(i) > 2
-            call add(dbs, trim(i))
-        endif
+  for i in split(out, "\n")
+    if len(i) > 2
+      call add(dbs, trim(i))
+    endif
 
-    endfor
+  endfor
 
-    return dbs
+  return dbs
 endfunction

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -1,81 +1,113 @@
-if !executable('bq')
-  echom 'bq command is not available.'
-  let g:autoloaded_db_bigquery = 0
-endif
-
 if exists('g:autoloaded_db_bigquery')
-  finish
+    finish
 endif
 
 let g:autoloaded_db_bigquery = 1
+let g:bq_global_ops = [
+    \ 'api',
+    \ 'api_version',
+    \ 'apilog',
+    \ 'bigqueryrc',
+    \ 'ca_certificates_file',
+    \ 'dataset_id',
+    \ 'debug_mode',
+    \ 'nodebug_mode',
+    \ 'disable_ssl_validation',
+    \ 'nodisable_ssl_validation',
+    \ 'discovery_file',
+    \ 'enable_gdrive',
+    \ 'noenable_gdrive',
+    \ 'fingerprint_job_id',
+    \ 'nofingerprint_job_id',
+    \ 'format',
+    \ 'headless',
+    \ 'noheadless',
+    \ 'httplib2_debuglevel',
+    \ 'job_id',
+    \ 'job_property',
+    \ 'jobs_query_use_request_id',
+    \ 'nojobs_query_use_request_id',
+    \ 'jobs_query_use_results_from_response',
+    \ 'nojobs_query_use_results_from_response',
+    \ 'location',
+    \ 'max_rows_per_request',
+    \ 'mtls',
+    \ 'nomtls',
+    \ 'project_id',
+    \ 'proxy_address',
+    \ 'proxy_password',
+    \ 'proxy_port',
+    \ 'proxy_username',
+    \ 'quiet',
+    \ 'noquiet',
+    \ 'synchronous_mode',
+    \ 'nosynchronous_mode',
+    \ 'trace',
+    \ 'use_regional_endpoints',
+    \ 'nouse_regional_endpoints',
+    \ ]
+
 
 function! s:command_for_url(params, action) abort
-  let cmd = ['bq']
-  let subcmd = [a:action]
+    let cmd = ['bq']
+    let subcmd = [a:action]
 
-  for [k, v] in items(a:params)
-    let op = ' --'.k.'='.v
+    for [k, v] in items(a:params)
+        let op = '--'.k.'='.v
+        if index(g:bq_global_ops, k) >= 0
+            " parse global options
+            call add(cmd, op)
+        else
+            " parse subcmd options
+            call add(subcmd, op)
+        endif
+    endfor
 
-    if len(matchstr(k, 'legacy'))
-        " FIXME: parse subcmd options
-        call add(subcmd, op)
-    else
-        " parse global options
-        call add(cmd, op)
-    endif
-
-  endfor
-
-  return join(cmd + subcmd)
-
+    return cmd + subcmd
 endfunction
 
 function! s:params(url) abort
-  let parsed_params = db#url#parse(a:url)
-  let conn_params = parsed_params.params
-  return conn_params
+    let parsed_params = db#url#parse(a:url)
+    let conn_params = parsed_params.params
+    return conn_params
 endfunction
 
 function! db#adapter#bigquery#interactive(url, action) abort
-  echom "Starting bigquery"
-  return split(s:command_for_url(s:params(a:url), a:action))
+    echom "Starting bigquery"
+    return s:command_for_url(s:params(a:url), a:action)
 endfunction
 
 function! db#adapter#bigquery#input(url, in) abort
 
-  " QST: what is the purpose of input?
-  let qry = join(readfile(a:in, 2))
-  if len(qry)
-    " QST: why I have to add this condition?
-    return db#adapter#bigquery#interactive(a:url, "query") + [qry]
-  endif
-
-  return []
-
-endfunction
-
-function! db#adapter#bigquery#complete_opaque(url) abort
-  " QST: don't know why this is required
-  return db#adapter#bigquery#complete_database(a:url)
-endfunction
-
-function! db#adapter#bigquery#complete_database(url) abort
-  let cmd = s:command_for_url(s:params(a:url))
-  let cmd .= ' ls '
-  echom "system" cmd
-  let out = system(cmd)
-  echom "out" out
-  let dbs = []
-
-  " FIXME: this is not working properly
-  for i in split(out, "\n")
-    " let dbname = split(i, "|")
-    if len(i) > 2
-      call add(dbs, trim(i))
+    let out = []
+    if len(matchstr(a:in, '.sql'))
+        let out += db#adapter#bigquery#interactive(a:url, 'query')
+        let out += ['--flagfile=' . a:in]
     endif
 
-  endfor
+    return out
+endfunction
 
-  return dbs
+" function! db#adapter#bigquery#complete_opaque(url) abort
+"     return db#adapter#bigquery#complete_database(a:url)
+" endfunction
 
+function! db#adapter#bigquery#complete_database(url) abort
+    let cmd = s:command_for_url(s:params(a:url))
+    let cmd .= ' ls '
+    echom "system" cmd
+    let out = system(cmd)
+    echom "out" out
+    let dbs = []
+
+    " FIXME: this is not working properly
+    for i in split(out, "\n")
+        " let dbname = split(i, "|")
+        if len(i) > 2
+            call add(dbs, trim(i))
+        endif
+
+    endfor
+
+    return dbs
 endfunction

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -88,7 +88,9 @@ bigquery ~
     bigquery://?dataset_id=publicdata:samples&format=sparse select count(*) from shakespeare
     bigquery://?use_legacy_sql=true sparse select count(*) from publicdata.samples.shakespeare
 <
-This adapter uses `bq` underhood.
+
+This adapter uses `bq` underhood which means that google sdk must be installed
+https://cloud.google.com/sdk/docs/install.
 
                                                 *dadbod-dbext*
 dbext ~

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -81,6 +81,15 @@ Handling these parameters is up to the individual adapters.  By default,
 unrecognized parameters are ignored.  Pass Boolean parameters as the literal
 strings "true" and "false" (e.g., `?ssl=true`).
 
+                                                *dadbod-bigquery*
+bigquery ~
+>
+    bigquery://[?<option>=<value>][&<option>=<value>][...]
+    bigquery://?dataset_id=publicdata:samples&format=sparse select count(*) from shakespeare
+    bigquery://?use_legacy_sql=true sparse select count(*) from publicdata.samples.shakespeare
+<
+This adapter uses `bq` underhood.
+
                                                 *dadbod-dbext*
 dbext ~
 >


### PR DESCRIPTION
I'm trying my best to include bigquery support for dadbod. I like to get some feedback before continue as I know there are some flaws (I'm not an vim-plugin expert). 

# In summary:

- Delegates into `bq` command (that has to be installed and configurated)
- `bq` has global and "local" options that can be set by the url e.g: `DB bigquery://?use_legacy_sql=True&dataset_id=publicdata:samples select * from shakespeare` (`dataset_id` is global, `use_legacy_sql` is local as only valid under `bq query` subcommand.

# `bq` Examples

- `bq --dataset_id=publicdata:samples query "select * from shakespeare limit 5" `
- `bq query "select * from publicdata.samples.shakespeare limit 5"`
- `bq ls` # list datasets

related #95 #104 #79 
