### PR TITLE
Adding ssl support to presto adapter.

### DIFF
--- a/autoload/db/adapter/presto.vim
+++ b/autoload/db/adapter/presto.vim
@@ -26,6 +26,20 @@ function! s:options(url) abort
       let options.schema = path[1]
     endif
   endif
+
+  if has_key(url.params,'keystore-path')
+    let options["keystore-path"] = url.params['keystore-path']
+  endif
+
+  if has_key(url.params, 'truststore-path')
+    let options['truststore-path'] = url.params['truststore-path']
+  endif
+
+  " not an actual trino/presto parameter this is used to get
+  " around incorrectly interpreting hosts with a sheme specified
+  if has_key(url.params, 'https')
+    let options.server = 'https://' . options.server
+  endif
   return options
 endfunction
 


### PR DESCRIPTION
Currently the `presto` adapter doesn't support they `keysstore-path` and `truststore-path` parameters which can be used for custom SSL key setups. This is an attempt to add support for those.

Also, I had an issue any time I specified a `:DB presto://https://hostname?...` I opted to add support for it as a parameter on the schema. I imagine there's a better place to add this support, maybe `db#url#parse` but I'm not very familiar with vimscript regex differences, happy to rework that bit if necessary.