### PR TITLE
Add BigQuery Adapter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,7 @@ take on [dbext.vim][], improving on it on the following ways:
 * All interaction is through invoking `:DB`, not 53 different commands and 35
   different maps (omitting many of the more esoteric features, of course)
 * Supports a modern array of backends, including NoSQL databases:
+  - Big Query
   - ClickHouse
   - Impala
   - jq

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -1,25 +1,8 @@
 function! db#adapter#bigquery#auth_input() abort
-  " Return false to skip providing authentication credentials;
-  " instead use the default credentials in the environment when
-  " the bq CLI is run.
-  "   https://cloud.google.com/bigquery/docs/authentication
   return v:false
 endfunction
 
 function! s:command_for_url(url, subcmd) abort
-  " Return a bq CLI command string to execute by the system bq binary for a
-  " vim-dadbod (BigQuery) database url and shell subcommand.
-  "
-  " The provided url may have query-string encoded arguments in the format:
-  "   biqquery:[project[:dataset]]//?arg1=value1&arg2=value2[...]
-  "
-  " The query string will be converted to global bq CLI arguments, e.g.:
-  "   bq --arg1=val1 --arg2=val2 [subcommand]
-  "
-  " Note: if the project_id/dataset_id are supplied in both the
-  " hostname and params substrings, duplicate arguments will be
-  " passed to the bq CLI, which uses the last value supplied.
-
   let cmd = ['bq']
   let parsed = db#url#parse(a:url)
   if has_key(parsed, 'opaque')
@@ -43,17 +26,9 @@ function! s:command_for_url(url, subcmd) abort
 endfunction
 
 function! db#adapter#bigquery#filter(url) abort
-  " Return a bq CLI command string to execute with `bq query`.
-  "
-  " For more information, please refer to:
-  "  https://cloud.google.com/bigquery/docs/running-queries#bq
   return s:command_for_url(a:url, 'query')
 endfunction
 
 function! db#adapter#bigquery#interactive(url) abort
-  " Return a bq CLI command string to execute with `bq shell`.
-  "
-  " For more information, please refer to:
-  "  https://cloud.google.com/bigquery/docs/bq-command-line-tool#interactive
   return s:command_for_url(a:url, 'shell')
 endfunction

--- a/autoload/db/adapter/bigquery.vim
+++ b/autoload/db/adapter/bigquery.vim
@@ -1,0 +1,59 @@
+function! db#adapter#bigquery#auth_input() abort
+  " Return false to skip providing authentication credentials;
+  " instead use the default credentials in the environment when
+  " the bq CLI is run.
+  "   https://cloud.google.com/bigquery/docs/authentication
+  return v:false
+endfunction
+
+function! s:command_for_url(url, subcmd) abort
+  " Return a bq CLI command string to execute by the system bq binary for a
+  " vim-dadbod (BigQuery) database url and shell subcommand.
+  "
+  " The provided url may have query-string encoded arguments in the format:
+  "   biqquery:[project[:dataset]]//?arg1=value1&arg2=value2[...]
+  "
+  " The query string will be converted to global bq CLI arguments, e.g.:
+  "   bq --arg1=val1 --arg2=val2 [subcommand]
+  "
+  " Note: if the project_id/dataset_id are supplied in both the
+  " hostname and params substrings, duplicate arguments will be
+  " passed to the bq CLI, which uses the last value supplied.
+
+  let cmd = ['bq']
+  let parsed = db#url#parse(a:url)
+  if has_key(parsed, 'opaque')
+    let host_targets = split(substitute(parsed.opaque, '/', '', 'g'), ':')
+
+    " If the host is specified as bigquery:project:dataset, then parse
+    " the optional (project, dataset) to supply them to the CLI.
+    if len(host_targets) == 2
+      call add(cmd, '--project_id=' . host_targets[0])
+      call add(cmd, '--dataset_id=' . host_targets[1])
+    elseif len(host_targets) == 1
+      call add(cmd, '--project_id=' . host_targets[0])
+    endif
+  endif
+
+  for [k, v] in items(parsed.params)
+    let op = '--'.k.'='.v
+    call add(cmd, op)
+  endfor
+  return cmd + [a:subcmd]
+endfunction
+
+function! db#adapter#bigquery#filter(url) abort
+  " Return a bq CLI command string to execute with `bq query`.
+  "
+  " For more information, please refer to:
+  "  https://cloud.google.com/bigquery/docs/running-queries#bq
+  return s:command_for_url(a:url, 'query')
+endfunction
+
+function! db#adapter#bigquery#interactive(url) abort
+  " Return a bq CLI command string to execute with `bq shell`.
+  "
+  " For more information, please refer to:
+  "  https://cloud.google.com/bigquery/docs/bq-command-line-tool#interactive
+  return s:command_for_url(a:url, 'shell')
+endfunction

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -92,7 +92,6 @@ The first form of the URL assumes your default dataset belongs to your default p
 
 Additional query parameters can be any valid global flag, for example, `&disable_ssl_validation=true`.  Note that subcommand flags are not supported as query parameters, but they can be specified in `~/.bigqueryrc`.
 
-
                                                 *dadbod-dbext*
 dbext ~
 >

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -84,11 +84,7 @@ strings "true" and "false" (e.g., `?ssl=true`).
                                                 *dadbod-bigquery*
 bigquery ~
 >
-    bigquery://[?<globalflag>=<value>][&<globalflag>=<value>][...]
-    bigquery://?format=sparse select count(*) from publicdata.samples.shakespeare
-    bigquery://?dataset_id=publicdata:samples&format=json select count(*) from shakespeare
-    bigquery:[project]// select count(*) from publicdata.samples.shakespeare
-    bigquery:[project:dataset]// select count(*) from publicdata.samples.shakespeare
+    bigquery:[?<globalflag>=<value>][&<globalflag>=<value>][...]
 <
 This adapter uses the `bq` command line tool provided by the Google Cloud SDK.
 Please ensure this is installed first as per: https://cloud.google.com/sdk/docs/install.
@@ -106,7 +102,7 @@ may wish to specify both a project and a `dataset_id` .
 For example, the following query will run in `your-exec-project` but resolve
 the table `shakespeare` to `dataset_id=publicdata:samples.shakespeare`:
 
-    `bigquery:your-exec-project//?dataset_id=publicdata:samples select count(*) from shakespeare`
+    `bigquery:your-exec-project?dataset_id=publicdata:samples select count(*) from shakespeare`
 
                                                 *dadbod-dbext*
 dbext ~

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -81,6 +81,33 @@ Handling these parameters is up to the individual adapters.  By default,
 unrecognized parameters are ignored.  Pass Boolean parameters as the literal
 strings "true" and "false" (e.g., `?ssl=true`).
 
+                                                *dadbod-bigquery*
+bigquery ~
+>
+    bigquery://[?<globalflag>=<value>][&<globalflag>=<value>][...]
+    bigquery://?format=sparse select count(*) from publicdata.samples.shakespeare
+    bigquery://?dataset_id=publicdata:samples&format=json select count(*) from shakespeare
+    bigquery:[project]// select count(*) from publicdata.samples.shakespeare
+    bigquery:[project:dataset]// select count(*) from publicdata.samples.shakespeare
+<
+This adapter uses the `bq` command line tool provided by the Google Cloud SDK.
+Please ensure this is installed first as per: https://cloud.google.com/sdk/docs/install.
+
+Please note that `bq` accepts both *global* flags and *command* flags for the
+`bq query` subcommand, however *only* global flags are currently supported as
+query parameters by dadbod. To specify subcommand defaults, please use your
+local `~/.biqgqueryrc`.
+
+The query *execution* project and default dataset may be specified in the address hostname
+as `bigquery:project:dataset` or as parameters. Please remember that the
+execution project differes in general from the data storage project, and you
+may wish to specify both a project and a `dataset_id` .
+
+For example, the following query will run in `your-exec-project` but resolve
+the table `shakespeare` to `dataset_id=publicdata:samples.shakespeare`:
+
+    `bigquery:your-exec-project//?dataset_id=publicdata:samples select count(*) from shakespeare`
+
                                                 *dadbod-dbext*
 dbext ~
 >

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -84,25 +84,14 @@ strings "true" and "false" (e.g., `?ssl=true`).
                                                 *dadbod-bigquery*
 bigquery ~
 >
-    bigquery:[?<globalflag>=<value>][&<globalflag>=<value>][...]
+    bigquery:[<project_id>[:<dataset_id>]][?...]
+    bigquery:?project_id=<project_id>&dataset_id=<dataset_id>[&...]
 <
-This adapter uses the `bq` command line tool provided by the Google Cloud SDK.
-Please ensure this is installed first as per: https://cloud.google.com/sdk/docs/install.
 
-Please note that `bq` accepts both *global* flags and *command* flags for the
-`bq query` subcommand, however *only* global flags are currently supported as
-query parameters by dadbod. To specify subcommand defaults, please use your
-local `~/.biqgqueryrc`.
+The first form of the URL assumes your default dataset belongs to your default project.  If it doesn't, use the second form.
 
-The query *execution* project and default dataset may be specified in the address hostname
-as `bigquery:project:dataset` or as parameters. Please remember that the
-execution project differes in general from the data storage project, and you
-may wish to specify both a project and a `dataset_id` .
+Additional query parameters can be any valid global flag, for example, `&disable_ssl_validation=true`.  Note that subcommand flags are not supported as query parameters, but they can be specified in `~/.bigqueryrc`.
 
-For example, the following query will run in `your-exec-project` but resolve
-the table `shakespeare` to `dataset_id=publicdata:samples.shakespeare`:
-
-    `bigquery:your-exec-project?dataset_id=publicdata:samples select count(*) from shakespeare`
 
                                                 *dadbod-dbext*
 dbext ~


### PR DESCRIPTION
# Summary

- This PR creates an adapter for Google BigQuery based on the [`bq` CLI tool](https://cloud.google.com/bigquery/docs/reference/bq-cli-reference)
- It incorporates and builds on the commits in https://github.com/tpope/vim-dadbod/pull/118 (thanks @mmngreco!) and addresses the feedback provided by @tpope there

## Issues Addressed
- https://github.com/tpope/vim-dadbod/issues/95
- https://github.com/tpope/vim-dadbod/issues/104
- https://github.com/tpope/vim-dadbod/issues/79

## Implementation Notes

- The adapter calls the `bq query` command and passes the buffer query to `stdin`

### Questions / Notes for @tpope 

#### (resolved) Context: `bq` authentication
- Invocations of the `bq` CLI are typically authenticated using the user's [or agent's] current google cloud SDK credentials, either directly from variables in the shell environment or from local configuration files
- This environment-based authentication means that there isn't typically a need to provide `user/password` credentials in a connection string when  connecting to BigQuery, unlike many OLTP databases (and their existing dadbod adapters)
- This was the root of the problem encountered previously in https://github.com/tpope/vim-dadbod/pull/118, raised in [this review thread](https://github.com/tpope/vim-dadbod/pull/118#discussion_r1038899402):
   - IIUC the issue stemmed from the `db#connect` [calls](https://github.com/tpope/vim-dadbod/blob/master/autoload/db.vim#L318) in which `vim-dadbod` assumes that some credentials need to be passed to the database client CLI to open an interactive session
   - Since there isn't anything to pass in, this is problematic and causes BQ to read an empty file to the `stdin` (it's expecting a *query*, not interactive input)

#### (resolved) Duplicate `bq` Calls

- To address the auth issue and still pass the query using the `stdin`, I've implemented a *dummy* auth input that passes `select 1` to `bq`:
![image](https://user-images.githubusercontent.com/10452129/222332009-fdf1f3d8-860d-441b-8f63-4cbaeb1f53fb.png)

- This means that there are *2 round trips* made to BQ to execute a query (which does technically confirm that the user can authenticate), and since it's an OLAP database it's pretty damn slow to do this; each query, small or large, has 1-2 seconds overhead

- All in all it means that simple queries are *twice* as slow as they need to be. The extra 2 seconds probably doesn't matter for long-running queries, but this could definitely be improved. However, I don't know how to improve it based on my understanding of the current codebase;
  - If the auth step could be skipped, that would be ideal!
  - However if skipping it requires using the `#inputs` method that provides a file, this will be problematic for `bq`, since it only accepts a comandline string or `stdin`; there is AFAIK no way to pass a file according to the [docs](https://cloud.google.com/bigquery/docs/reference/bq-cli-reference#bq_query)

#### Downstream `vim-dadbod-ui` Usage

- This also integrates with the `dadbod-ui` as per https://github.com/kristijanhusak/vim-dadbod-ui/pull/160
