### PR TITLE
SQL Server adapter: update parameters for latest version of sqlcmd

### DIFF
--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -175,8 +175,11 @@ SQL Server ~
     sqlserver://[<user>[:<password>]@][<host>][:<port>]/[<database>]
     sqlserver://[<host>[:<port>]][;user=<user>][;...]
 <
-Supported query parameters are `secure` and `trustServerCertificate`, which
-correspond to connection properties of the same name.
+Supported query parameters are `encrypt-connection`, `format`,
+`column-separator`, `trim-spaces` and `trust-server-certificate`, which
+correspond to connection properties of the same name (see `sqlcmd -?`). For
+backward compatibility with older versions of sqlcmd the boolean query
+parameters `secure` and `trustServerCertificate` can be used.
 
 To set the `integratedSecurity` connection property and use a trusted
 connection, omit the user and password.


### PR DESCRIPTION
Based on this issue https://github.com/tpope/vim-dadbod/issues/127 and latest docs for `sqlcmd` the password is now supplied in `SQLCMDPASSWORD` environment variable. I also updated the adapter to properly support `encrypt-connection`, `format`, `column-separator`, `trim-spaces` and `trust-server-certificate` options. For backward compatibility I left there old flags `secure` and `trustServerCertificate`.