### PR TITLE
SQL Server adapter: supply password in environment variable

### DIFF
--- a/autoload/db/adapter/sqlserver.vim
+++ b/autoload/db/adapter/sqlserver.vim
@@ -42,7 +42,7 @@ endfunction
 
 function! db#adapter#sqlserver#interactive(url) abort
   let url = db#url#parse(a:url)
-  return ['env', 'SQLCMDPASSWORD=' . get(url, 'password'), 'sqlcmd', '-S', s:server(url)] +
+  return ['env', 'SQLCMDPASSWORD=' . get(url, 'password', ''), 'sqlcmd', '-S', s:server(url)] +
         \ s:boolean_param_flag(url, 'encrypt', '-N') +
         \ s:boolean_param_flag(url, 'trustServerCertificate', '-C') +
         \ (has_key(url, 'user') ? [] : ['-E']) +

--- a/autoload/db/adapter/sqlserver.vim
+++ b/autoload/db/adapter/sqlserver.vim
@@ -42,11 +42,11 @@ endfunction
 
 function! db#adapter#sqlserver#interactive(url) abort
   let url = db#url#parse(a:url)
-  return ['sqlcmd', '-S', s:server(url)] +
+  return ['env', 'SQLCMDPASSWORD=' . get(url, 'password'), 'sqlcmd', '-S', s:server(url)] +
         \ s:boolean_param_flag(url, 'encrypt', '-N') +
         \ s:boolean_param_flag(url, 'trustServerCertificate', '-C') +
         \ (has_key(url, 'user') ? [] : ['-E']) +
-        \ db#url#as_argv(url, '', '', '', '-U ', '-P ', '-d ')
+        \ db#url#as_argv(url, '', '', '', '-U ', '', '-d ')
 endfunction
 
 function! db#adapter#sqlserver#input(url, in) abort


### PR DESCRIPTION
sqlcmd no longer accept password using parameter `-P` - fixed based on [this](https://github.com/tpope/vim-dadbod/issues/127#issuecomment-1488454491) comment

related to https://github.com/tpope/vim-dadbod/pull/133#issuecomment-1553288886

