### PR TITLE
Put semicolon before port in impala file

### DIFF
--- a/autoload/db/adapter/impala.vim
+++ b/autoload/db/adapter/impala.vim
@@ -13,7 +13,7 @@ function! s:params(url) abort
     let impala_params.impalad = params.host
   endif
   if has_key(params, 'port')
-    let impala_params.impalad .= params.port
+    let impala_params.impalad .= ":".params.port
   endif
   if has_key(params, 'path')
     let path = split(params.path, '/')


### PR DESCRIPTION
```
:DB impala://fake.host.com:1234
```

was giving me

```
impala-shell --impalad fake.host.com1234
```

## unrelated

thanks for all of the awesome tools!