### PR TITLE
Add DuckDB adapter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,7 @@ take on [dbext.vim][], improving on it on the following ways:
 * Supports a modern array of backends, including NoSQL databases:
   - Big Query
   - ClickHouse
+  - DuckDB
   - Impala
   - jq
   - MongoDB

--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -395,7 +395,7 @@ function! s:init() abort
   if empty(maparg('gq', 'n'))
     exe 'nnoremap <buffer><silent>' (v:version < 704 ? '' : '<nowait>') 'gq :bdelete<CR>'
   endif
-  nnoremap <buffer><nowait> r :DB <C-R>=get(readfile(b:db_input, 1), 0)<CR>
+  nnoremap <buffer><nowait> r :DB <C-R>=get(readfile(b:db_input, '', 1), 0)<CR>
   nnoremap <buffer><silent> R :call <SID>reload()<CR>
   nnoremap <buffer><silent> <C-c> :call db#cancel()<CR>
 endfunction
@@ -488,7 +488,7 @@ function! db#execute_command(mods, bang, line1, line2, cmd) abort
           let lines = split(db#adapter#call(conn, 'massage', [str], str), "\n", 1)
         elseif !empty(maybe_infile)
           let lines = repeat([''], a:line1-1) +
-                \ readfile(expand(maybe_infile), a:line2)[(a:line1)-1 : -1]
+                \ readfile(expand(maybe_infile), '', a:line2)[(a:line1)-1 : -1]
         elseif a:line1 == 1 && a:line2 == line('$') && empty(cmd) && !&modified && filereadable(expand('%'))
           let infile = expand('%:p')
         else

--- a/autoload/db/adapter/duckdb.vim
+++ b/autoload/db/adapter/duckdb.vim
@@ -1,0 +1,45 @@
+function! db#adapter#duckdb#canonicalize(url) abort
+  return db#url#canonicalize_file(a:url)
+endfunction
+
+function! db#adapter#duckdb#test_file(file) abort
+  if getfsize(a:file) < 100
+    return
+  endif
+  let firstline = readfile(a:file, 1)[0]
+  " DuckDB can also open SQLite databases
+  if firstline[8:11] ==# 'DUCK' || firstline =~# '^SQLite format 3\n'
+    return 1
+  endif
+endfunction
+
+function! s:path(url) abort
+  let path = db#url#file_path(a:url)
+  if path =~# '^[\/]\=$'
+    if !exists('s:session')
+      let s:session = tempname() . '.duckdb'
+    endif
+    let path = s:session
+  endif
+  return path
+endfunction
+
+function! db#adapter#duckdb#dbext(url) abort
+  return {'dbname': s:path(a:url)}
+endfunction
+
+function! db#adapter#duckdb#command(url) abort
+  return ['duckdb', s:path(a:url)]
+endfunction
+
+function! db#adapter#duckdb#interactive(url) abort
+  return db#adapter#duckdb#command(a:url) + ['-column', '-header']
+endfunction
+
+function! db#adapter#duckdb#tables(url) abort
+  return split(join(db#systemlist(db#adapter#duckdb#command(a:url) + ['-noheader', '.tables'])))
+endfunction
+
+function! db#adapter#duckdb#massage(input) abort
+  return a:input . "\n;"
+endfunction

--- a/autoload/db/adapter/duckdb.vim
+++ b/autoload/db/adapter/duckdb.vim
@@ -6,7 +6,7 @@ function! db#adapter#duckdb#test_file(file) abort
   if getfsize(a:file) < 100
     return
   endif
-  let firstline = readfile(a:file, 1)[0]
+  let firstline = readfile(a:file, '', 1)[0]
   " DuckDB can also open SQLite databases
   if firstline[8:11] ==# 'DUCK' || firstline =~# '^SQLite format 3\n'
     return 1

--- a/autoload/db/adapter/sqlite.vim
+++ b/autoload/db/adapter/sqlite.vim
@@ -3,7 +3,7 @@ function! db#adapter#sqlite#canonicalize(url) abort
 endfunction
 
 function! db#adapter#sqlite#test_file(file) abort
-  if getfsize(a:file) >= 100 && readfile(a:file, 1)[0] =~# '^SQLite format 3\n'
+  if getfsize(a:file) >= 100 && readfile(a:file, '', 1)[0] =~# '^SQLite format 3\n'
     return 1
   endif
 endfunction

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -108,6 +108,16 @@ ClickHouse ~
 <
 Use the `secure` query parameter to enable TLS.
 
+                                                *dadbod-duckdb*
+DuckDB ~
+>
+    duckdb:relative/path
+    duckdb:/absolute/path
+    duckdb:C:/windows/path
+<
+An empty path portion uses an in-memory database, which is occasionally useful
+for an interactive invocation.
+
                                                 *dadbod-impala*
 Impala ~
 >


### PR DESCRIPTION
This PR adds an adapter for DuckDB—the SQLite for analytics.

## Implementation

I copied and tweaked the sqlite adapter as the duckdb cli accepts the same arguments the adapter uses.

The `db#adapter#duckdb#test_file` function checks for the magic bytes (DUCK) in the storage header as described in [DuckDB Storage](https://duckdb.org/internals/storage.html#storage-header).

## Fixes

The second commit fixes incorrect `readfile()` calls across the repo.