### PR TITLE
Add mysql adapter command global variable

### DIFF
--- a/autoload/db/adapter/mysql.vim
+++ b/autoload/db/adapter/mysql.vim
@@ -13,7 +13,17 @@ endfunction
 
 function! s:command_for_url(url) abort
   let params = db#url#parse(a:url).params
-  let command = ['mysql']
+  " check the global mysql client command first
+  " if it's not there, try the use the global variable g:db#adapter#mysql#command
+  " if that's not there, use the default mysql client command
+  
+  if executable('mysql')
+    let command = ['mysql']
+  elseif exists('g:db#adapter#mysql#command')
+    let command = [g:db#adapter#mysql#command]
+  else
+    let command = ['mysql']
+  endif
 
   for i in keys(params)
     let command += ['--'.i.'='.params[i]]

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -72,6 +72,8 @@ t:db, b:db, $DATABASE_URL, and g:db will be used.  Suggested uses:
 Set a variable with |:let|, or use |:DB| to normalize the URL first:
 >
     :DB w:db = adapter://...
+
+You can use g:db#adapter#mysql#command to set the binary command to use when connecting, e.g. let g:db#adapter#mysql#command = 'mycli'
 <
 ADAPTERS                                        *dadbod-adapters*
 


### PR DESCRIPTION
Because the command I use locally to connect to mysql is not mysql, I use mycli. Causes me to get the error "mysql not found" when I use it, so I hope that the command to connect mysql can be customized with variables