### PR TITLE
Fix jq adapter by short-circuiting auth

### DIFF
--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -337,7 +337,7 @@ function! db#connect(url) abort
       return url
     endif
     call writefile(split(auth_input, "\n", 1), input, 'b')
-    let [out, exit_status] = call('s:systemlist', s:filter(url, input))
+    let [out, exit_status] = call('s:systemlist', filter)
     if exit_status && join(out, "\n") =~? pattern && resolved =~# '^[^:]*://[^:/@]*@'
       let password = inputsecret('Password: ')
       let url = substitute(resolved, '://[^:/@]*\zs@', ':'.db#url#encode(password).'@', '')

--- a/autoload/db/adapter/jq.vim
+++ b/autoload/db/adapter/jq.vim
@@ -23,6 +23,10 @@ function! db#adapter#jq#input(url, in) abort
   return ['jq', '--from-file', a:in] + s:path_args(a:url)
 endfunction
 
+function! db#adapter#jq#auth_input() abort
+  return v:false
+endfunction
+
 function! db#adapter#jq#tables(url) abort
   return db#systemlist(['jq', '--raw-output', '[.. | objects | keys[]] | unique[]'] + s:path_args(a:url))
 endfunction


### PR DESCRIPTION
The authentication test in the "connect" function is not functioning correctly for the "jq" adapter. Since there is no authentication mechanism available, we might as well use the short-circuit code path.

To reproduce the issue:
```
$ nvim -c 'DB jq: .'
```

The error message output is:
```
jq: error: Top-level program not given (try ".")
jq: 1 compile error
```
