### PR TITLE
Fix incorrect keymap in documentation

### DIFF
--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -26,7 +26,7 @@ USAGE                                           *dadbod* *:DB*
                         |g:dadbod_manage_dbext|.
 
 In the preview window, you can press "R" to rerun, "r" to interactively rerun,
-or "q" to close the window.
+or "gq" to close the window.
 
 URLS                                            *dadbod-urls*
 


### PR DESCRIPTION
The documentation says to press 'q' to close preview window, but when doing so a message says that you should press 'gq'.