### PR TITLE
Add support for AzureAD auth (#152)

### DIFF
--- a/autoload/db/adapter/sqlserver.vim
+++ b/autoload/db/adapter/sqlserver.vim
@@ -48,6 +48,7 @@ function! db#adapter#sqlserver#interactive(url) abort
         \ (empty(encrypt) ? [] : ['-N'] + (encrypt ==# '1' ? [] : [url.params.encrypt])) +
         \ s:boolean_param_flag(url, 'trustServerCertificate', '-C') +
         \ (has_key(url, 'user') ? [] : ['-E']) +
+        \ (has_key(url.params, 'authentication') ? ['--authentication-method', url.params.authentication] : []) +
         \ db#url#as_argv(url, '', '', '', '-U ', '', '-d ')
 endfunction
 

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -186,8 +186,9 @@ SQL Server ~
     sqlserver://[<user>[:<password>]@][<host>][:<port>]/[<database>]
     sqlserver://[<host>[:<port>]][;user=<user>][;...]
 <
-Supported query parameters are `secure` and `trustServerCertificate`, which
-correspond to connection properties of the same name.
+Supported query parameters are `authentication`, `secure` and `trustServerCertificate`,
+which correspond to connection properties of the same name. The `authentication`
+property is only supported when using `go-sqlcmd`.
 
 To set the `integratedSecurity` connection property and use a trusted
 connection, omit the user and password.


### PR DESCRIPTION
As per discussion on #152 , I have added support for an `authentication` connection parameter, that maps onto the `--authentication-method` parameter of the `go-sqlcmd` CLI.