### PR TITLE
mysql: Fix socket connection when host default is not localhost

### DIFF
--- a/autoload/db/adapter/mysql.vim
+++ b/autoload/db/adapter/mysql.vim
@@ -19,7 +19,8 @@ function! s:command_for_url(url) abort
     let command += ['--'.i.'='.params[i]]
   endfor
 
-  return command + db#url#as_argv(a:url, '-h ', '-P ', '-S ', '-u ', '-p', '')
+  " -S only works for localhost, so force that, in case the default was overridden, e.g. in .my.cnf
+  return command + db#url#as_argv(a:url, '-h ', '-P ', '-h localhost -S ', '-u ', '-p', '')
 endfunction
 
 function! db#adapter#mysql#interactive(url) abort


### PR DESCRIPTION
The socket option of mysql only works when the hostname is set to localhost. As the mysql adapter doesn't set a hostname at all when a socket is given, this breaks when the default hostname has been set to something else than localhost, e.g. in a user's .my.cnf file. As one can't give both a hostname and a socket path at the same time, we can to simply force the hostname to localhost when a socket path is used to make things work again.