### PR TITLE
Add capabilities for listing procedures and functions in Postgresql and MySQL adapters

### DIFF
--- a/autoload/db/adapter/mysql.vim
+++ b/autoload/db/adapter/mysql.vim
@@ -49,3 +49,13 @@ endfunction
 function! db#adapter#mysql#tables(url) abort
   return db#systemlist(s:command_for_url(a:url) + ['-e', 'show tables'])[1:-1]
 endfunction
+
+function! db#adapter#mysql#procedures(url) abort
+  " return db#systemlist(s:command_for_url(a:url) + ['-e', 'SHOW PROCEDURE STATUS'])[1:-1]
+  return db#systemlist(s:command_for_url(a:url) + ['-N', '-e', 'select concat(db, ''.'', name) name from mysql.proc where db=database() and type=''PROCEDURE'''])[1:-1]
+endfunction
+
+function! db#adapter#mysql#functions(url) abort
+  " return db#systemlist(s:command_for_url(a:url) + ['-e', 'SHOW FUNCTION STATUS'])[1:-1]
+  return db#systemlist(s:command_for_url(a:url) + ['-N', '-e', 'select concat(db, ''.'', name) name from mysql.proc where db=database() and type=''FUNCTION'''])[1:-1]
+endfunction

--- a/autoload/db/adapter/postgresql.vim
+++ b/autoload/db/adapter/postgresql.vim
@@ -44,3 +44,13 @@ function! db#adapter#postgresql#tables(url) abort
   return s:parse_columns(db#systemlist(
         \ db#adapter#postgresql#filter(a:url) + ['--no-psqlrc', '-tA', '-c', '\dtvm']), 1)
 endfunction
+
+function! db#adapter#postgresql#procedures(url) abort
+  return s:parse_columns(db#systemlist(
+        \ db#adapter#postgresql#filter(a:url) + ['--no-psqlrc', '-tA', '-c', '\dfp']), 1)
+endfunction
+
+function! db#adapter#postgresql#functions(url) abort
+  return s:parse_columns(db#systemlist(
+        \ db#adapter#postgresql#filter(a:url) + ['--no-psqlrc', '-tA', '-c', '\dfn']), 1)
+endfunction


### PR DESCRIPTION
I started developing to add the feature to list procedures and functions.

At the moment I have only developed for PostgreSQL and MySQL. It is necessary to extend the development for other types of DBMS.

This PR is required for developing list of stored procedures and functions in vim-dadbod-ui

This is the main issue: https://github.com/kristijanhusak/vim-dadbod-ui/issues/245