### PR TITLE
Update redis to support tls redis (rediss:)

### DIFF
--- a/autoload/db/adapter/redis.vim
+++ b/autoload/db/adapter/redis.vim
@@ -7,7 +7,12 @@ function! db#adapter#redis#canonicalize(url) abort
 endfunction
 
 function! db#adapter#redis#interactive(url) abort
-  return ['redis-cli'] + db#url#as_argv(a:url, '-h ', '-p ', '', '', '-a ', '-n ')
+  let extra_args = []
+  if a:url =~# '^rediss'
+    let extra_args = ['--tls']
+  endif
+
+  return ['redis-cli'] + db#url#as_argv(a:url, '-h ', '-p ', '', '--user ', '-a ', '-n ') + extra_args
 endfunction
 
 function! db#adapter#redis#auth_input() abort

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -184,11 +184,16 @@ Presto ~
                                                 *dadbod-redis*
 Redis ~
 >
-    redis://[[unused[:<password>]@]<host>]/[<database-number>]
     redis:[<database-number>]
+    redis://[:<password>@][<host>[:port]]/[<database-number>]
+    redis://[<user>[:<password>]@][<host>[:port]]/[<database-number>]
+    rediss://[<user>[:<password>]@][<host>[:port]]/[<database-number>]
 <
-Redis doesn't have a username, so use a dummy one in the URL if a password is
-required.
+Redis now supports user and you can supply both the user and password in the
+url.  If you only need the password and no user, you can accomplish this by
+leaving the user portion of the url empty.
+
+Redis also supports tls using rediss://
 
                                                 *dadbod-sqlserver*
 SQL Server ~

--- a/plugin/dadbod.vim
+++ b/plugin/dadbod.vim
@@ -18,6 +18,8 @@ call extend(g:db_adapters, {
 
 call extend(g:, {'db_adapter_mongodb#srv': 'db#adapter#mongodb#'}, 'keep')
 
+call extend(g:, {'db_adapter_rediss': 'db#adapter#redis#'}, 'keep')
+
 call extend(g:, {'dbext_schemes': {}}, 'keep')
 
 call extend(g:dbext_schemes, {


### PR DESCRIPTION
There are two small changes in this PR.
1. To correctly support user being supplied in the redis url for authentication.
2. Enable `rediss:` as the means to support TLS for redis connections.

If there is a more concise way to be more DRY between the normal and tls redis adapters please let me know.