### PR TITLE
Fix -E parameter conflict with AAD authentication

### DIFF
--- a/autoload/db/adapter/sqlserver.vim
+++ b/autoload/db/adapter/sqlserver.vim
@@ -43,12 +43,13 @@ endfunction
 function! db#adapter#sqlserver#interactive(url) abort
   let url = db#url#parse(a:url)
   let encrypt = get(url.params, 'encrypt', get(url.params, 'Encrypt', ''))
+  let has_authentication = has_key(url.params, 'authentication')
   return (has_key(url, 'password') ? ['env', 'SQLCMDPASSWORD=' . url.password] : []) +
         \ ['sqlcmd', '-S', s:server(url)] +
         \ (empty(encrypt) ? [] : ['-N'] + (encrypt ==# '1' ? [] : [url.params.encrypt])) +
         \ s:boolean_param_flag(url, 'trustServerCertificate', '-C') +
-        \ (has_key(url, 'user') ? [] : ['-E']) +
-        \ (has_key(url.params, 'authentication') ? ['--authentication-method', url.params.authentication] : []) +
+        \ (has_key(url, 'user') || has_authentication ? [] : ['-E']) +
+        \ (has_authentication ? ['--authentication-method', url.params.authentication] : []) +
         \ db#url#as_argv(url, '', '', '', '-U ', '', '-d ')
 endfunction
 


### PR DESCRIPTION
When no username is passed to the sqlserver connection URL, the adapter adds the -E parameter to the sqlcmd command. However, when using ActiveDirectoryDefault in the --authentication-method parameter, it doesn't work because the go-sqlcmd program will choose integrated authentication instead of AAD authentication.

Integrated authentication is chosen in go-sqlcmd either because the -E parameter is provided or because the username is empty and the authentication method is not specified.

This commit prevents the -E parameter from being passed if the authentication method parameter is provided, ensuring that AAD authentication can be used properly.