### PR TITLE
Add MotherDuck adapter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,7 @@ take on [dbext.vim][], improving on it on the following ways:
   - Impala
   - jq
   - MongoDB
+  - MotherDuck
   - MySQL
   - MariaDB
   - Oracle

--- a/autoload/db/adapter/duckdb.vim
+++ b/autoload/db/adapter/duckdb.vim
@@ -33,7 +33,7 @@ function! db#adapter#duckdb#command(url) abort
 endfunction
 
 function! db#adapter#duckdb#interactive(url) abort
-  return db#adapter#duckdb#command(a:url) + ['-column', '-header']
+  return db#adapter#duckdb#command(a:url) + ['-cmd', '.output']
 endfunction
 
 function! db#adapter#duckdb#tables(url) abort

--- a/autoload/db/adapter/md.vim
+++ b/autoload/db/adapter/md.vim
@@ -2,17 +2,6 @@ function! db#adapter#md#canonicalize(url) abort
   return a:url
 endfunction
 
-function! db#adapter#md#test_file(file) abort
-  if getfsize(a:file) < 100
-    return
-  endif
-  let firstline = readfile(a:file, '', 1)[0]
-  " DuckDB can also open SQLite databases
-  if firstline[8:11] ==# 'DUCK' || firstline =~# '^SQLite format 3\n'
-    return 1
-  endif
-endfunction
-
 function! s:dbname(url) abort
   let parsed = db#url#parse(a:url)
   if has_key(parsed, 'opaque')

--- a/autoload/db/adapter/md.vim
+++ b/autoload/db/adapter/md.vim
@@ -1,0 +1,45 @@
+function! db#adapter#md#canonicalize(url) abort
+  return db#url#canonicalize_file(a:url)
+endfunction
+
+function! db#adapter#md#test_file(file) abort
+  if getfsize(a:file) < 100
+    return
+  endif
+  let firstline = readfile(a:file, '', 1)[0]
+  " DuckDB can also open SQLite databases
+  if firstline[8:11] ==# 'DUCK' || firstline =~# '^SQLite format 3\n'
+    return 1
+  endif
+endfunction
+
+function! s:path(url) abort
+  let path = db#url#file_path(a:url)
+  if path =~# '^[\/]\=$'
+    if !exists('s:session')
+      let s:session = tempname() . '.duckdb'
+    endif
+    let path = s:session
+  endif
+  return path
+endfunction
+
+function! db#adapter#md#dbext(url) abort
+  return {'dbname': s:path(a:url)}
+endfunction
+
+function! db#adapter#md#command(url) abort
+  return ['duckdb', s:path(a:url)]
+endfunction
+
+function! db#adapter#md#interactive(url) abort
+  return db#adapter#md#command(a:url) + ['-column', '-header']
+endfunction
+
+function! db#adapter#md#tables(url) abort
+  return split(join(db#systemlist(db#adapter#md#command(a:url) + ['-noheader', '.tables'])))
+endfunction
+
+function! db#adapter#md#massage(input) abort
+  return a:input . "\n;"
+endfunction

--- a/autoload/db/adapter/md.vim
+++ b/autoload/db/adapter/md.vim
@@ -18,8 +18,8 @@ function! db#adapter#md#command(url) abort
   let cmd = ['duckdb']
   let dbname = s:dbname(a:url)
   if dbname != ''
-    let attach = ['-cmd', "attach 'md:" . dbname . "'"]
-    let use = ['-cmd', 'use ' . dbname]
+    let attach = ['-cmd', "attach 'md:" . dbname . "' as " . '"' . dbname . '"']
+    let use = ['-cmd', "use '" . dbname . "'"]
     let cmd = cmd + attach + use
   else
     let attach = ['-cmd', "attach 'md:'"]

--- a/autoload/db/adapter/md.vim
+++ b/autoload/db/adapter/md.vim
@@ -26,18 +26,21 @@ function! db#adapter#md#dbext(url) abort
 endfunction
 
 function! db#adapter#md#command(url) abort
+  let cmd = ['duckdb']
   let dbname = s:dbname(a:url)
   if dbname != ''
-    let attachment = "attach 'md:" . dbname . "'; use " . dbname . ";"
+    let attach = ['-cmd', "attach 'md:" . dbname . "'"]
+    let use = ['-cmd', 'use ' . dbname]
+    let cmd = cmd + attach + use
   else
-    let attachment = "attach 'md:';"
+    let attach = ['-cmd', "attach 'md:'"]
+    let cmd = cmd + attach
   endif
-  let cmd = ['duckdb', '-cmd', attachment]
   return cmd
 endfunction
 
 function! db#adapter#md#interactive(url) abort
-  return db#adapter#md#command(a:url) + ['-box', '-header']
+  return db#adapter#md#command(a:url) + ['-cmd', '.output', '-header']
 endfunction
 
 function! db#adapter#md#tables(url) abort

--- a/autoload/db/adapter/md.vim
+++ b/autoload/db/adapter/md.vim
@@ -44,7 +44,7 @@ function! db#adapter#md#interactive(url) abort
 endfunction
 
 function! db#adapter#md#tables(url) abort
-  return split(join(db#systemlist(db#adapter#md#command(a:url) + ['-noheader', '.tables'])))
+  return split(join(db#systemlist(db#adapter#md#command(a:url) + ['-noheader', '-c', '.tables'])))
 endfunction
 
 function! db#adapter#md#massage(input) abort

--- a/autoload/db/adapter/md.vim
+++ b/autoload/db/adapter/md.vim
@@ -33,7 +33,7 @@ function! db#adapter#md#command(url) abort
 endfunction
 
 function! db#adapter#md#interactive(url) abort
-  return db#adapter#md#command(a:url) + ['-column', '-header']
+  return db#adapter#md#command(a:url) + ['-box', '-header']
 endfunction
 
 function! db#adapter#md#tables(url) abort

--- a/autoload/db/adapter/md.vim
+++ b/autoload/db/adapter/md.vim
@@ -1,5 +1,5 @@
 function! db#adapter#md#canonicalize(url) abort
-  return db#url#canonicalize_file(a:url)
+  return a:url
 endfunction
 
 function! db#adapter#md#test_file(file) abort

--- a/autoload/db/adapter/md.vim
+++ b/autoload/db/adapter/md.vim
@@ -40,7 +40,7 @@ function! db#adapter#md#command(url) abort
 endfunction
 
 function! db#adapter#md#interactive(url) abort
-  return db#adapter#md#command(a:url) + ['-cmd', '.output', '-header']
+  return db#adapter#md#command(a:url) + ['-cmd', '.output']
 endfunction
 
 function! db#adapter#md#tables(url) abort

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -143,6 +143,20 @@ MongoDB ~
 <
 Any valid MongoDB connection string URI can be used.
 
+                                                *dadbod-md*
+MotherDuck ~
+>
+    md:
+    md:database
+<
+MotherDuck authenticates using a token stored as an environment variable
+`motherduck_token`. If this environment variable is missing, all invocations
+will open a browser and prompt the user to login to the MotherDuck console.
+
+If the database is provided, it will be used as the default database (so
+queries do not have to specify a database. If not, queries must specify a
+database.
+
                                                 *dadbod-mysql*
 MySQL ~
 >

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -147,7 +147,7 @@ Any valid MongoDB connection string URI can be used.
 MotherDuck ~
 >
     md:
-    md:database
+    md:[<database>]
 <
 MotherDuck authenticates using a token stored as an environment variable
 `motherduck_token`. If this environment variable is missing, all invocations


### PR DESCRIPTION
Add an adapter, based on the existing DuckDB adapter, for [MotherDuck](https://motherduck.com/) (cloud-hosted serverless DuckDB).

This also improves the output format of the existing DuckDB adapter to use `duckbox` instead of `columns`.

For example:
Before:
![image](https://github.com/user-attachments/assets/861e7b26-aecd-4221-91e4-8c11dd80263a)

After:
![image](https://github.com/user-attachments/assets/a475a828-fd55-4d02-a8bd-ced90d505509)

Note in particular the presence of data types in column headers.

TODO:
- [x] Basic functionality with `:DB md: [query]` and `:DB md:[database] [query]`
- [x] List tables for basic integration with [vim-dadbod-ui](https://github.com/kristijanhusak/vim-dadbod-ui)
- [x] Add documentation