### PR TITLE
feat(db): add custom query output formatter

### DIFF
--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -313,7 +313,13 @@ function! s:query_callback(query, start_reltime, lines, status) abort
   let job = remove(a:query, 'job')
   let a:query.runtime = reltimefloat(reltime(a:start_reltime))
   let a:query.exit_status = a:status
-  call writefile(a:lines, a:query.output, 'b')
+  
+  let output_lines = a:lines
+  if exists('g:db_custom_formatter') && type(g:db_custom_formatter) == v:t_func
+    let output_lines = call(g:db_custom_formatter, [a:query.db_url, output_lines])
+  endif
+  
+  call writefile(output_lines, a:query.output, 'b')
   let status_msg = 'DB: Query ' . string(a:query.output)
   let status_msg .= a:status ? ' aborted after ' : ' finished in '
   let status_msg .= printf('%.3fs', a:query.runtime)

--- a/doc/dadbod.txt
+++ b/doc/dadbod.txt
@@ -230,6 +230,23 @@ avoids this ambiguity.
 An empty path portion uses an in-memory database, which is occasionally useful
 for an interactive invocation.
 
+CUSTOM OUTPUT FORMATTING                       *g:db_custom_formatter*
+
+You can set a custom formatter function to process query results before they are
+displayed. The function should take two arguments: the database URL and the 
+array of output lines, and return the modified array of lines:
+>
+  function! MyFormatter(db_url, lines) abort
+    " Process output lines here
+    return processed_lines
+  endfunction
+  let g:db_custom_formatter = function('MyFormatter')
+<
+
+For instance, if your database query output contains records with newline characters 
+that are split into separate lines, you might want to join them back together
+for a more readable output.
+
 DBEXT MANAGEMENT                                *g:dadbod_manage_dbext*
 
 If you like Dadbod's configuration but need some of dbext's functionality, set


### PR DESCRIPTION
- Introduced `g:db_custom_formatter` for custom query result formatting.
- Updated documentation with usage details and example.
