### PR TITLE
Use utf8 in channel and for sqlserver

### DIFF
--- a/autoload/db.vim
+++ b/autoload/db.vim
@@ -173,6 +173,12 @@ function! s:nvim_job_callback(lines, job_id, data, event) dict abort
   call extend(a:lines, a:data[1:])
 endfunction
 
+if has("win32")
+  let s:win_utf8_fix = ['cmd', '/c', 'chcp', '65001', '>', 'nul', '&&']
+else
+  let s:win_utf8_fix = []
+endif
+
 function! s:job_run(cmd, on_finish, in_file) abort
   let has_in_file = filereadable(a:in_file)
   let env = {}
@@ -185,7 +191,7 @@ function! s:job_run(cmd, on_finish, in_file) abort
   endif
   if has('nvim')
     let lines = ['']
-    let job = jobstart(a:cmd, {
+    let job = jobstart(s:win_utf8_fix + a:cmd, {
           \ 'env': env,
           \ 'on_stdout': function('s:nvim_job_callback', [lines]),
           \ 'on_stderr': function('s:nvim_job_callback', [lines]),

--- a/autoload/db/adapter/sqlserver.vim
+++ b/autoload/db/adapter/sqlserver.vim
@@ -45,7 +45,7 @@ function! db#adapter#sqlserver#interactive(url) abort
   let encrypt = get(url.params, 'encrypt', get(url.params, 'Encrypt', ''))
   let has_authentication = has_key(url.params, 'authentication')
   return (has_key(url, 'password') ? ['env', 'SQLCMDPASSWORD=' . url.password] : []) +
-        \ ['sqlcmd', '-S', s:server(url)] +
+        \ ['sqlcmd', '-f', 'i:65001,o:65001', '-S', s:server(url)] +
         \ (empty(encrypt) ? [] : ['-N'] + (encrypt ==# '1' ? [] : [url.params.encrypt])) +
         \ s:boolean_param_flag(url, 'trustServerCertificate', '-C') +
         \ (has_key(url, 'user') || has_authentication ? [] : ['-E']) +


### PR DESCRIPTION
In a windows terminal, the character set is typically *not* UTF-8. This means that Windows users will most likely read and/or write wrong data when using vim-dadbod, if they use characters outside ASCII.

This patch does two things to fix this problem:
  1. Prepend `chcp 65001` before the command of any database tool used by dadbod, but only when running on Windows. Code page 65001 is Microsofts name for UTF-8. (This fixes reading from most database tools)
  2. Add command-line arguments to sqlcmd (used to communicate with SQL Server) to use utf-8. (This was necessary to write data correctly to sqlserver. It might not be needed on other platforms than windows, but certainly does not hurt. Other tools might need similar fixes).

See also https://github.com/tpope/vim-dadbod/issues/193